### PR TITLE
Add const constructor to intrusive_adapter

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -172,7 +172,12 @@ macro_rules! intrusive_adapter {
         unsafe impl<$($args $(: ?$bound)*),*> Sync for $name<$($args),*> $($where_)* {}
         #[allow(dead_code)]
         impl<$($args $(: ?$bound)*),*> $name<$($args),*> $($where_)* {
+            #[cfg(not(feature = "nightly"))]
             pub fn new() -> Self {
+                $name($crate::__core::marker::PhantomData)
+            }
+            #[cfg(feature = "nightly")]
+            pub const fn new() -> Self {
                 $name($crate::__core::marker::PhantomData)
             }
         }


### PR DESCRIPTION
This adds a const constructor to intrusive_adapter macro. It's useful
when initializing a static variable, for example.