### PR TITLE
Clippy cleanup

### DIFF
--- a/src/intrusive_pointer.rs
+++ b/src/intrusive_pointer.rs
@@ -56,7 +56,7 @@ unsafe impl<'a, T: ?Sized> IntrusivePointer<T> for &'a T {
 unsafe impl<T: ?Sized> IntrusivePointer<T> for UnsafeRef<T> {
     #[inline]
     fn into_raw(self) -> *const T {
-        UnsafeRef::into_raw(self)
+        UnsafeRef::into_raw(&self)
     }
     #[inline]
     unsafe fn from_raw(ptr: *const T) -> Self {

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1000,7 +1000,7 @@ mod tests {
         UnsafeRef::from_box(Box::new(Obj {
             link1: Link::new(),
             link2: Link::default(),
-            value: value,
+            value,
         }))
     }
 

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1248,13 +1248,11 @@ impl<A: for<'a> KeyAdapter<'a, Link = Link>> RBTree<A> {
                         } else {
                             tree = tree.left();
                         }
-                    } else {
-                        if tree.right().is_null() {
+                    } else if tree.right().is_null() {
                             tree.insert_right(new, &mut self.root);
                             break;
-                        } else {
-                            tree = tree.right();
-                        }
+                    } else {
+                        tree = tree.right();
                     }
                 }
             }
@@ -1679,7 +1677,7 @@ mod tests {
     fn make_obj(value: i32) -> UnsafeRef<Obj> {
         UnsafeRef::from_box(Box::new(Obj {
             link: Link::new(),
-            value: value,
+            value,
         }))
     }
 

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -770,7 +770,7 @@ mod tests {
         UnsafeRef::from_box(Box::new(Obj {
             link1: Link::new(),
             link2: Link::default(),
-            value: value,
+            value,
         }))
     }
 

--- a/src/unsafe_ref.rs
+++ b/src/unsafe_ref.rs
@@ -64,7 +64,7 @@ impl<T: ?Sized> UnsafeRef<T> {
 
     /// Converts an `UnsafeRef` into a raw pointer
     #[inline]
-    pub fn into_raw(ptr: Self) -> *mut T {
+    pub fn into_raw(ptr: &Self) -> *mut T {
         ptr.ptr
     }
 }
@@ -86,8 +86,8 @@ impl<T: ?Sized> UnsafeRef<T> {
     /// collections. This operation is only valid if the `UnsafeRef` was
     /// created using `UnsafeRef::from_box`.
     #[inline]
-    pub unsafe fn into_box(ptr: Self) -> Box<T> {
-        Box::from_raw(UnsafeRef::into_raw(ptr))
+    pub unsafe fn into_box(ptr: &Self) -> Box<T> {
+        Box::from_raw(UnsafeRef::into_raw(&ptr))
     }
 }
 

--- a/src/unsafe_ref.rs
+++ b/src/unsafe_ref.rs
@@ -45,7 +45,7 @@ impl<T: ?Sized> UnsafeRef<T> {
 
     /// Converts an `UnsafeRef` into a raw pointer
     #[inline]
-    pub fn into_raw(ptr: Self) -> *mut T {
+    pub fn into_raw(ptr: &Self) -> *mut T {
         ptr.ptr.as_ptr()
     }
 }


### PR DESCRIPTION
Thanks for publishing this library!

This reduces the clippy warnings to these two:

```
warning: methods called `into_*` usually take self by value; consider choosing a less ambiguous name                                                                                                     
  --> src/unsafe_ref.rs:67:21                                                                                                                                                                            
   |                                                                                                                                                                                                     
67 |     pub fn into_raw(ptr: &Self) -> *mut T {                                                                                                                                                         
   |                     ^^^                                                                                                                                                                             
   |                                                                                                                                                                                                     
   = note: #[warn(clippy::wrong_self_convention)] on by default                                                                                                                                          
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#wrong_self_convention                                                                       
                                                                                                                                                                                                         
warning: methods called `into_*` usually take self by value; consider choosing a less ambiguous name                                                                                                     
  --> src/unsafe_ref.rs:89:28                                                                                                                                                                            
   |                                                                                                                                                                                                     
89 |     pub unsafe fn into_box(ptr: &Self) -> Box<T> {                                                                                                                                                  
   |                            ^^^                                                                                                                                                                      
   |                                                                                                                                                                                                     
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#wrong_self_convention
```

This is tough. Changing the interface would probably be best long term, but this patch seemed a lesser evil than unnecessary ownership of `Self` in the relevant methods. I cleaned up a couple other clippy warnings. Apologies if this is unwelcome or not a good use of your time. I lint libraries I am learning from and sometimes PR what I changed.