### PR TITLE
Promote some features to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ extern crate intrusive_collections;
 
 This crate has two Cargo features:
 
-- `nightly`: Enables nightly-only features: `const fn` constructors, `NonZero` support for `UnsafeRef`.
+- `nightly`: Enables nightly-only features: `const fn` constructors for collections (`Link` constructors are always `const fn`)
 - `alloc` (enabled by default): Implements `IntrusivePointer` for `Box`, `Rc` and `Arc`. This requires `libstd` on stable, but only `liballoc` if the `nightly` feature is enabled.
 
 ## License

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -25,19 +25,8 @@ pub struct Link {
 
 impl Link {
     /// Creates a new `Link`.
-    #[cfg(feature = "nightly")]
     #[inline]
     pub const fn new() -> Link {
-        Link {
-            next: Cell::new(UNLINKED_MARKER),
-            prev: Cell::new(UNLINKED_MARKER),
-        }
-    }
-
-    /// Creates a new `Link`.
-    #[cfg(not(feature = "nightly"))]
-    #[inline]
-    pub fn new() -> Link {
         Link {
             next: Cell::new(UNLINKED_MARKER),
             prev: Cell::new(UNLINKED_MARKER),

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -30,23 +30,11 @@ pub struct Link {
 
 impl Link {
     /// Creates a new `Link`.
-    #[cfg(feature = "nightly")]
     #[inline]
     pub const fn new() -> Link {
         Link {
             left: Cell::new(NodePtr(ptr::null())),
             right: Cell::new(NodePtr(ptr::null())),
-            parent_color: Cell::new(UNLINKED_MARKER),
-        }
-    }
-
-    /// Creates a new `Link`.
-    #[cfg(not(feature = "nightly"))]
-    #[inline]
-    pub fn new() -> Link {
-        Link {
-            left: Cell::new(NodePtr::null()),
-            right: Cell::new(NodePtr::null()),
             parent_color: Cell::new(UNLINKED_MARKER),
         }
     }

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -25,18 +25,8 @@ pub struct Link {
 
 impl Link {
     /// Creates a new `Link`.
-    #[cfg(feature = "nightly")]
     #[inline]
     pub const fn new() -> Link {
-        Link {
-            next: Cell::new(UNLINKED_MARKER),
-        }
-    }
-
-    /// Creates a new `Link`.
-    #[cfg(not(feature = "nightly"))]
-    #[inline]
-    pub fn new() -> Link {
         Link {
             next: Cell::new(UNLINKED_MARKER),
         }

--- a/src/unsafe_ref.rs
+++ b/src/unsafe_ref.rs
@@ -10,7 +10,6 @@ use crate::alloc::boxed::Box;
 use core::borrow::Borrow;
 use core::fmt;
 use core::ops::Deref;
-#[cfg(feature = "nightly")]
 use core::ptr::NonNull;
 
 /// Unchecked shared pointer
@@ -23,13 +22,9 @@ use core::ptr::NonNull;
 /// moved, dropped or accessed through a mutable reference as long as at least
 /// one `UnsafeRef` is pointing to it.
 pub struct UnsafeRef<T: ?Sized> {
-    #[cfg(feature = "nightly")]
     ptr: NonNull<T>,
-    #[cfg(not(feature = "nightly"))]
-    ptr: *mut T,
 }
 
-#[cfg(feature = "nightly")]
 impl<T: ?Sized> UnsafeRef<T> {
     /// Creates an `UnsafeRef` from a raw pointer
     ///
@@ -47,25 +42,6 @@ impl<T: ?Sized> UnsafeRef<T> {
     #[inline]
     pub fn into_raw(ptr: Self) -> *mut T {
         ptr.ptr.as_ptr()
-    }
-}
-
-#[cfg(not(feature = "nightly"))]
-impl<T: ?Sized> UnsafeRef<T> {
-    /// Creates an `UnsafeRef` from a raw pointer
-    ///
-    /// # Safety
-    ///
-    /// You must ensure that the `UnsafeRef` guarantees are upheld.
-    #[inline]
-    pub unsafe fn from_raw(val: *const T) -> UnsafeRef<T> {
-        UnsafeRef { ptr: val as *mut _ }
-    }
-
-    /// Converts an `UnsafeRef` into a raw pointer
-    #[inline]
-    pub fn into_raw(ptr: Self) -> *mut T {
-        ptr.ptr
     }
 }
 
@@ -108,16 +84,9 @@ impl<T: ?Sized> Deref for UnsafeRef<T> {
 }
 
 impl<T: ?Sized> AsRef<T> for UnsafeRef<T> {
-    #[cfg(feature = "nightly")]
     #[inline]
     fn as_ref(&self) -> &T {
         unsafe { self.ptr.as_ref() }
-    }
-
-    #[cfg(not(feature = "nightly"))]
-    #[inline]
-    fn as_ref(&self) -> &T {
-        unsafe { &*self.ptr }
     }
 }
 


### PR DESCRIPTION
With the minimum Rust version bumped to 1.31, there's no need to feature gate `NonNull` usage or `const fn` constructors for `Link` types anymore. The collections `const fn` constructors don't work on stable so those are still gated.

```
error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
   --> src\linked_list.rs:625:6
    |
625 | impl<A: Adapter<Link = Link>> LinkedList<A> {
    |      ^
    |
    = help: add #![feature(const_fn)] to the crate attributes to enable

error: aborting due to previous error
```