### PR TITLE
use offset_of from memoffset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ nightly = []
 alloc = []
 default = ["alloc"]
 
+[dependencies]
+memoffset = "0.5"
+
 [dev-dependencies]
 rand = "0.3"
 typed-arena = "1.2"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -59,7 +59,7 @@ pub unsafe trait Adapter {
 #[macro_export(local_inner_macros)]
 macro_rules! offset_of {
     ($($inner:tt)*) => {
-        $crate::__memoffset::offset_of!($($inner)*)
+        ($crate::__memoffset::offset_of!($($inner)*) as isize)
     }
 }
 
@@ -88,7 +88,7 @@ macro_rules! container_of {
     ($ptr:expr, $container:path, $field:ident) => {
         #[allow(clippy::cast_ptr_alignment)]
         {
-            ($ptr as *const _ as *const u8).sub($crate::__memoffset::offset_of!($container, $field))
+            ($ptr as *const _ as *const u8).offset(-offset_of!($container, $field))
                 as *mut $container
         }
     };

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -54,6 +54,10 @@ pub unsafe trait Adapter {
     unsafe fn get_link(&self, value: *const Self::Value) -> *const Self::Link;
 }
 
+/// Macro to get the offset of a struct field in bytes from the address of the
+/// struct.
+pub use memoffset::offset_of;
+
 /// Unsafe macro to get a raw pointer to an outer object from a pointer to one
 /// of its fields.
 ///

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -56,7 +56,12 @@ pub unsafe trait Adapter {
 
 /// Macro to get the offset of a struct field in bytes from the address of the
 /// struct.
-pub use memoffset::offset_of;
+#[macro_export(local_inner_macros)]
+macro_rules! offset_of {
+    ($($inner:tt)*) => {
+        $crate::__memoffset::offset_of!($($inner)*)
+    }
+}
 
 /// Unsafe macro to get a raw pointer to an outer object from a pointer to one
 /// of its fields.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,9 @@ extern crate std;
 // Re-export core for use by macros
 #[doc(hidden)]
 pub extern crate core as __core;
+// Re-export memoffset for use by macros
+#[doc(hidden)]
+pub extern crate memoffset as __memoffset;
 
 mod intrusive_pointer;
 mod unsafe_ref;


### PR DESCRIPTION
In particular, this should avoid triggering the various [ways in which we try to warn about misusage of `mem::zeroed` and `mem::uninitialized`](https://internals.rust-lang.org/t/make-mem-uninitialized-and-mem-zeroed-panic-for-some-types-where-0-is-a-niche/10605). It also doesn't need a feature gate to use the "right" approach for versions of Rust that do support `MaybeUninit`.

Minimum Rust version of intrusive-rs seems to be Rust 1.31, so according to https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macros-with-crate-prefix using the `$crate::` prefix for macros should work. `memoffset` supports Rust 1.25+, so that seems fine as well.

Fixes https://github.com/Amanieu/intrusive-rs/issues/25.