### PR TITLE
Add a get_pointer method to all collections

### DIFF
--- a/src/intrusive_pointer.rs
+++ b/src/intrusive_pointer.rs
@@ -116,11 +116,9 @@ pub(crate) unsafe fn clone_pointer_from_raw<P: IntrusivePointer<T> + Clone, T: ?
 
     impl<P: IntrusivePointer<T>, T: ?Sized> Drop for PointerGuard<P, T> {
         fn drop(&mut self) {
-            if let Some(pointer) = self.pointer.take() {
-                // Prevent shared pointers from being released by converting them
-                // back into the raw pointers
-                let _ = pointer.into_raw();
-            }
+            // Prevent shared pointers from being released by converting them
+            // back into the raw pointers
+            let _ = self.pointer.take().unwrap().into_raw();
         }
     }
 
@@ -128,7 +126,7 @@ pub(crate) unsafe fn clone_pointer_from_raw<P: IntrusivePointer<T> + Clone, T: ?
         pointer: Some(P::from_raw(pointer)),
         _phantom: core::marker::PhantomData,
     };
-    holder.pointer.as_ref().map(|p| p.clone()).unwrap()
+    holder.pointer.as_ref().unwrap().clone()
 }
 
 #[cfg(test)]

--- a/src/intrusive_pointer.rs
+++ b/src/intrusive_pointer.rs
@@ -99,6 +99,38 @@ unsafe impl<T: ?Sized> IntrusivePointer<T> for Arc<T> {
     }
 }
 
+/// Creates an `IntrusivePointer` from a raw pointer
+///
+/// This method is only safe to call if the raw pointer is known to be
+/// managed by the provided `IntrusivePointer` type.
+pub(crate) unsafe fn clone_pointer_from_raw<P: IntrusivePointer<T> + Clone, T: ?Sized>(
+    pointer: *const T,
+) -> P {
+    /// Guard which converts an `IntrusivePointer` back into its raw version
+    /// when it gets dropped. This makes sure we also perform a full
+    /// `from_raw` and `into_raw` round trip - even in the case of panics.
+    struct PointerGuard<P: IntrusivePointer<T>, T: ?Sized> {
+        pointer: Option<P>,
+        _phantom: core::marker::PhantomData<T>,
+    }
+
+    impl<P: IntrusivePointer<T>, T: ?Sized> Drop for PointerGuard<P, T> {
+        fn drop(&mut self) {
+            if let Some(pointer) = self.pointer.take() {
+                // Prevent shared pointers from being released by converting them
+                // back into the raw pointers
+                let _ = pointer.into_raw();
+            }
+        }
+    }
+
+    let holder = PointerGuard {
+        pointer: Some(P::from_raw(pointer)),
+        _phantom: core::marker::PhantomData,
+    };
+    holder.pointer.as_ref().map(|p| p.clone()).unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::IntrusivePointer;
@@ -192,6 +224,28 @@ mod tests {
             let a2: *const dyn Debug = &*p2;
             assert_eq!(a, a2);
             assert_eq!(b, mem::transmute(a2));
+        }
+    }
+
+    #[test]
+    fn clone_arc_from_raw() {
+        use super::clone_pointer_from_raw;
+        unsafe {
+            let p = Arc::new(1);
+            let raw = &*p as *const i32;
+            let p2: Arc<i32> = clone_pointer_from_raw(raw);
+            assert_eq!(2, Arc::strong_count(&p2));
+        }
+    }
+
+    #[test]
+    fn clone_rc_from_raw() {
+        use super::clone_pointer_from_raw;
+        unsafe {
+            let p = Rc::new(1);
+            let raw = &*p as *const i32;
+            let p2: Rc<i32> = clone_pointer_from_raw(raw);
+            assert_eq!(2, Rc::strong_count(&p2));
         }
     }
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -234,6 +234,27 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
         }
     }
 
+    /// Clones and returns the pointer that points to the element that the
+    /// cursor is referencing.
+    ///
+    /// This returns None if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_pointer(&self) -> Option<A::Pointer>
+    where
+        A::Pointer: Clone,
+    {
+        if self.is_null() {
+            None
+        } else {
+            let pointer = unsafe {
+                let value = &*self.list.adapter.get_value(self.current.0);
+                core::mem::ManuallyDrop::new(A::Pointer::from_raw(value as *const A::Value))
+            };
+            Some((*pointer).clone())
+        }
+    }
+
     /// Moves the cursor to the next element of the `LinkedList`.
     ///
     /// If the cursor is pointer to the null object then this will move it to
@@ -1359,5 +1380,43 @@ mod tests {
         l.cursor_mut().insert_before(&b);
         assert_eq!(*l.front().get().unwrap().value, 5);
         assert_eq!(*l.back().get().unwrap().value, 5);
+    }
+
+    macro_rules! test_clone_pointer {
+        ($ptr: ident, $ptr_import: path) => {
+            use $ptr_import;
+
+            #[derive(Clone)]
+            struct Obj {
+                link: Link,
+                value: usize,
+            }
+            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link: Link });
+
+            let a = $ptr::new(Obj {
+                link: Link::new(),
+                value: 5,
+            });
+            let mut l = LinkedList::new(ObjAdapter::new());
+            l.cursor_mut().insert_before(a.clone());
+            assert_eq!(2, $ptr::strong_count(&a));
+
+            let pointer = l.front().get_pointer().unwrap();
+            assert_eq!(pointer.value, 5);
+            assert_eq!(3, $ptr::strong_count(&a));
+
+            l.front_mut().remove();
+            assert!(l.front().get_pointer().is_none());
+        }
+    }
+
+    #[test]
+    fn test_clone_pointer_rc() {
+        test_clone_pointer!(Rc, std::rc::Rc);
+    }
+
+    #[test]
+    fn test_clone_pointer_arc() {
+        test_clone_pointer!(Arc, std::sync::Arc);
     }
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -223,7 +223,7 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     /// Returns a reference to the object that the cursor is currently
     /// pointing to.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
     pub fn get(&self) -> Option<&'a A::Value> {
@@ -237,10 +237,10 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_pointer(&self) -> Option<A::Pointer>
+    pub fn clone_pointer(&self) -> Option<A::Pointer>
     where
         A::Pointer: Clone,
     {
@@ -1401,12 +1401,12 @@ mod tests {
             l.cursor_mut().insert_before(a.clone());
             assert_eq!(2, $ptr::strong_count(&a));
 
-            let pointer = l.front().get_pointer().unwrap();
+            let pointer = l.front().clone_pointer().unwrap();
             assert_eq!(pointer.value, 5);
             assert_eq!(3, $ptr::strong_count(&a));
 
             l.front_mut().remove();
-            assert!(l.front().get_pointer().is_none());
+            assert!(l.front().clone_pointer().is_none());
         }
     }
 

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -244,15 +244,8 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     where
         A::Pointer: Clone,
     {
-        if self.is_null() {
-            None
-        } else {
-            let pointer = unsafe {
-                let value = &*self.list.adapter.get_value(self.current.0);
-                core::mem::ManuallyDrop::new(A::Pointer::from_raw(value as *const A::Value))
-            };
-            Some((*pointer).clone())
-        }
+        let raw_pointer = self.get()? as *const A::Value;
+        Some(unsafe { crate::intrusive_pointer::clone_pointer_from_raw(raw_pointer) })
     }
 
     /// Moves the cursor to the next element of the `LinkedList`.

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -541,6 +541,27 @@ impl<'a, A: Adapter<Link = Link> + 'a> Cursor<'a, A> {
         }
     }
 
+    /// Clones and returns the pointer that points to the element that the
+    /// cursor is referencing.
+    ///
+    /// This returns None if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_pointer(&self) -> Option<A::Pointer>
+    where
+        A::Pointer: Clone,
+    {
+        if self.is_null() {
+            None
+        } else {
+            let pointer = unsafe {
+                let value = &*self.tree.adapter.get_value(self.current.0);
+                core::mem::ManuallyDrop::new(A::Pointer::from_raw(value as *const A::Value))
+            };
+            Some((*pointer).clone())
+        }
+    }
+
     /// Moves the cursor to the next element of the `RBTree`.
     ///
     /// If the cursor is pointer to the null object then this will move it to
@@ -1641,14 +1662,14 @@ impl<A: Adapter<Link = Link>> DoubleEndedIterator for IntoIter<A> {
 
 #[cfg(test)]
 mod tests {
+    use self::rand::{Rng, XorShiftRng};
     use super::{Entry, Link, RBTree};
     use crate::Bound::*;
     use crate::{KeyAdapter, UnsafeRef};
+    use rand;
     use std::boxed::Box;
     use std::fmt;
     use std::vec::Vec;
-    use rand;
-    use self::rand::{Rng, XorShiftRng};
 
     #[derive(Clone)]
     struct Obj {
@@ -2365,5 +2386,49 @@ mod tests {
         l.insert(&b);
         assert_eq!(*l.front().get().unwrap().value, 5);
         assert_eq!(*l.back().get().unwrap().value, 5);
+    }
+
+    macro_rules! test_clone_pointer {
+        ($ptr: ident, $ptr_import: path) => {
+            use $ptr_import;
+
+            #[derive(Clone)]
+            struct Obj {
+                link: Link,
+                value: usize,
+            }
+            intrusive_adapter!(ObjAdapter = $ptr<Obj>: Obj { link: Link });
+            impl<'a> KeyAdapter<'a> for ObjAdapter {
+                type Key = usize;
+                fn get_key(&self, value: &'a Obj) -> usize {
+                    value.value
+                }
+            }
+
+            let a = $ptr::new(Obj {
+                link: Link::new(),
+                value: 5,
+            });
+            let mut l = RBTree::new(ObjAdapter::new());
+            l.insert(a.clone());
+            assert_eq!(2, $ptr::strong_count(&a));
+
+            let pointer = l.front().get_pointer().unwrap();
+            assert_eq!(pointer.value, 5);
+            assert_eq!(3, $ptr::strong_count(&a));
+
+            l.front_mut().remove();
+            assert!(l.front().get_pointer().is_none());
+        }
+    }
+
+    #[test]
+    fn test_clone_pointer_rc() {
+        test_clone_pointer!(Rc, std::rc::Rc);
+    }
+
+    #[test]
+    fn test_clone_pointer_arc() {
+        test_clone_pointer!(Arc, std::sync::Arc);
     }
 }

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -530,7 +530,7 @@ impl<'a, A: Adapter<Link = Link> + 'a> Cursor<'a, A> {
     /// Returns a reference to the object that the cursor is currently
     /// pointing to.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
     pub fn get(&self) -> Option<&'a A::Value> {
@@ -544,10 +544,10 @@ impl<'a, A: Adapter<Link = Link> + 'a> Cursor<'a, A> {
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_pointer(&self) -> Option<A::Pointer>
+    pub fn clone_pointer(&self) -> Option<A::Pointer>
     where
         A::Pointer: Clone,
     {
@@ -2413,12 +2413,12 @@ mod tests {
             l.insert(a.clone());
             assert_eq!(2, $ptr::strong_count(&a));
 
-            let pointer = l.front().get_pointer().unwrap();
+            let pointer = l.front().clone_pointer().unwrap();
             assert_eq!(pointer.value, 5);
             assert_eq!(3, $ptr::strong_count(&a));
 
             l.front_mut().remove();
-            assert!(l.front().get_pointer().is_none());
+            assert!(l.front().clone_pointer().is_none());
         }
     }
 

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -551,15 +551,8 @@ impl<'a, A: Adapter<Link = Link> + 'a> Cursor<'a, A> {
     where
         A::Pointer: Clone,
     {
-        if self.is_null() {
-            None
-        } else {
-            let pointer = unsafe {
-                let value = &*self.tree.adapter.get_value(self.current.0);
-                core::mem::ManuallyDrop::new(A::Pointer::from_raw(value as *const A::Value))
-            };
-            Some((*pointer).clone())
-        }
+        let raw_pointer = self.get()? as *const A::Value;
+        Some(unsafe { crate::intrusive_pointer::clone_pointer_from_raw(raw_pointer) })
     }
 
     /// Moves the cursor to the next element of the `RBTree`.

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -213,15 +213,8 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     where
         A::Pointer: Clone,
     {
-        if self.is_null() {
-            None
-        } else {
-            let pointer = unsafe {
-                let value = &*self.list.adapter.get_value(self.current.0);
-                core::mem::ManuallyDrop::new(A::Pointer::from_raw(value as *const A::Value))
-            };
-            Some((*pointer).clone())
-        }
+        let raw_pointer = self.get()? as *const A::Value;
+        Some(unsafe { crate::intrusive_pointer::clone_pointer_from_raw(raw_pointer) })
     }
 
     /// Moves the cursor to the next element of the `SinglyLinkedList`.

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -192,7 +192,7 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     /// Returns a reference to the object that the cursor is currently
     /// pointing to.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
     pub fn get(&self) -> Option<&'a A::Value> {
@@ -206,10 +206,10 @@ impl<'a, A: Adapter<Link = Link>> Cursor<'a, A> {
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
-    /// This returns None if the cursor is currently pointing to the null
+    /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_pointer(&self) -> Option<A::Pointer>
+    pub fn clone_pointer(&self) -> Option<A::Pointer>
     where
         A::Pointer: Clone,
     {
@@ -1125,12 +1125,12 @@ mod tests {
             l.cursor_mut().insert_after(a.clone());
             assert_eq!(2, $ptr::strong_count(&a));
 
-            let pointer = l.front().get_pointer().unwrap();
+            let pointer = l.front().clone_pointer().unwrap();
             assert_eq!(pointer.value, 5);
             assert_eq!(3, $ptr::strong_count(&a));
 
             l.clear();
-            assert!(l.front().get_pointer().is_none());
+            assert!(l.front().clone_pointer().is_none());
         }
     }
 


### PR DESCRIPTION
This adds a method which allows to retrieve the pointer that is used to
store the element in the collection, and not only the collection.

Fixes #24