### PR TITLE
remove nightly requirement for using alloc crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.31.0
+- 1.36.0
 
 before_script:
 - |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,10 +282,8 @@
 #![cfg_attr(feature = "nightly", feature(const_fn, allow_internal_unstable))]
 
 // Use liballoc on nightly to avoid a dependency on libstd
-#[cfg(all(feature = "nightly", feature = "alloc"))]
+#[cfg(all(feature = "alloc"))]
 extern crate alloc;
-#[cfg(all(not(feature = "nightly"), feature = "alloc"))]
-extern crate std as alloc;
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
the alloc crate was stabilized in 1.36.0.

in other words.. are you ok with bumping up the MRSV for the "alloc" build to 1.36.0, which was released on July 4, 2019?