### PR TITLE
Add support for Pin<P>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.36.0
+- 1.39.0
 
 before_script:
 - |


### PR DESCRIPTION
Add support for Pin pointer types to DefaultPointerOps so that users can
use a type like Pin<Box<T>> inside the intrusive_adapter! macro.
Intrusive collections inherently rely on the values having stable memory
locations and don't provide a way to get a mutable reference to the
value so they uphold the guarantees of pinning.