### PR TITLE
add into_ref for CursorMut

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1052,6 +1052,16 @@ where
             list
         }
     }
+
+    /// Consumes `CursorMut` and returns a reference to the object that
+    /// the cursor is currently pointing to. Unlike [get](Self::get),
+    /// the returned reference's lifetime is tied to `LinkedList`'s lifetime.
+    ///
+    /// This returns None if the cursor is currently pointing to the null object.
+    #[inline]
+    pub fn into_ref(self) -> Option<&'a <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
 }
 
 // =============================================================================

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1413,6 +1413,16 @@ where
             }
         }
     }
+
+    /// Consumes `CursorMut` and returns a reference to the object that
+    /// the cursor is currently pointing to. Unlike [get](Self::get),
+    /// the returned reference's lifetime is tied to `RBTree`'s lifetime.
+    ///
+    /// This returns None if the cursor is currently pointing to the null object.
+    #[inline]
+    pub fn into_ref(self) -> Option<&'a <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { &*self.tree.adapter.get_value(self.current?) })
+    }
 }
 
 impl<'a, A: for<'b> KeyAdapter<'b>> CursorMut<'a, A>

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -828,6 +828,16 @@ where
             list
         }
     }
+
+    /// Consumes `CursorMut` and returns a reference to the object that
+    /// the cursor is currently pointing to. Unlike [get](Self::get),
+    /// the returned reference's lifetime is tied to `SinglyLinkedList`'s lifetime.
+    ///
+    /// This returns None if the cursor is currently pointing to the null object.
+    #[inline]
+    pub fn into_ref(self) -> Option<&'a <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
 }
 
 // =============================================================================

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1070,6 +1070,16 @@ where
             list
         }
     }
+
+    /// Consumes `CursorMut` and returns a reference to the object that
+    /// the cursor is currently pointing to. Unlike [get](Self::get),
+    /// the returned reference's lifetime is tied to `XorLinkedList`'s lifetime.
+    ///
+    /// This returns None if the cursor is currently pointing to the null object.
+    #[inline]
+    pub fn into_ref(self) -> Option<&'a <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
This PR adds an ability to reuse existing RBTree's `CursorMut` instance to get reference to a pointee value that may outlive cursor, like `Cursor::get` does