### PR TITLE
Update memoffset version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.39.0, stable, beta, nightly]
+        rust: [1.56.1, stable, beta, nightly]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ alloc = []
 default = ["alloc"]
 
 [dependencies]
-memoffset = "0.5.4"
+memoffset = "0.8"
 
 [dev-dependencies]
 rand = "0.8.4"


### PR DESCRIPTION
Seems like newer version works just fine.

memoffset 0.8 is in Debian archive and I prefer if we can use that version instead of old version.
 