### PR TITLE
Allow collection and cursor to be safely contained in the same struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intrusive-collections"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "Intrusive collections for Rust (linked list and red-black tree)"
 documentation = "https://docs.rs/intrusive-collections"

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -16,9 +16,11 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
-use crate::unchecked_option::UncheckedOptionExt;
 use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
+// Necessary for Rust 1.56 compatability
+#[allow(unused_imports)]
+use crate::unchecked_option::UncheckedOptionExt;
 
 // =============================================================================
 // LinkedListOps

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1180,7 +1180,7 @@ where
     /// This returns None if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get(&self) -> Option<&'a <A::PointerOps as PointerOps>::Value> {
+    pub fn get(&self) -> Option<&<A::PointerOps as PointerOps>::Value> {
         Some(unsafe { &*self.tree.adapter.get_value(self.current?) })
     }
 

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1463,7 +1463,7 @@ where
 {
     /// Consumes self and returns the inner `RBTree`.
     #[inline]
-    pub fn take_tree(self) -> RBTree<A> {
+    pub fn into_inner(self) -> RBTree<A> {
         self.tree
     }
 
@@ -2713,13 +2713,13 @@ mod tests {
         };
         assert!(con.cur.as_cursor().is_null());
 
-        con.cur = con.cur.take_tree().front_owning();
+        con.cur = con.cur.into_inner().front_owning();
         assert_eq!(con.cur.as_cursor().get().unwrap().value, 1);
 
-        con.cur = con.cur.take_tree().back_owning();
+        con.cur = con.cur.into_inner().back_owning();
         assert_eq!(con.cur.as_cursor().get().unwrap().value, 4);
 
-        con.cur = con.cur.take_tree().find_owning(&2);
+        con.cur = con.cur.into_inner().find_owning(&2);
         assert_eq!(con.cur.as_cursor().get().unwrap().value, 2);
 
         con.cur.with_cursor_mut(|c| c.move_next());

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1496,6 +1496,12 @@ where
         ret
     }
 }
+unsafe impl<A: Adapter> Send for CursorOwning<A>
+where
+    RBTree<A>: Send,
+    A::LinkOps: RBTreeOps,
+{
+}
 
 // =============================================================================
 // RBTree

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -25,6 +25,9 @@ use crate::singly_linked_list::SinglyLinkedListOps;
 use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
 use crate::KeyAdapter;
+// Necessary for Rust 1.56 compatability
+#[allow(unused_imports)]
+use crate::unchecked_option::UncheckedOptionExt;
 
 // =============================================================================
 // RBTreeOps

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -19,8 +19,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
-use crate::unchecked_option::UncheckedOptionExt;
 use crate::Adapter;
+// Necessary for Rust 1.56 compatability
+#[allow(unused_imports)]
+use crate::unchecked_option::UncheckedOptionExt;
 
 // =============================================================================
 // XorLinkedListOps


### PR DESCRIPTION
At the moment it doesn't appear to be possible to create a struct which represents an owned collection and a position in it without the use of raw pointers. Ideally this would be done like this:
```Rust
struct Object {
    collection: RBTree<...>,
    cursor: Cursor<'?, ...>,
}
```
However, this isn't possible because of the self-referential nature of this struct.

Instead I propose a new type of cursor, `CursorOwning`, to coexist with `Cursor` and `CursorMut`. It would be mostly functionally equivalent to `CursorMut`, except its lifetime wouldn't be bounded by that of the collection, as it would own it rather than borrow it.

For now I've implemented this for the `RBTree` collection, and I'm willing to do the same for the rest of the library if accepted.