### PR TITLE
Eliminated memory leaks due to use of Rc in tests for fast_clear and …

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -17,6 +17,7 @@ use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
 use crate::xor_linked_list::XorLinkedListOps;
+use crate::unchecked_option::UncheckedOptionExt;
 use crate::Adapter;
 
 // =============================================================================

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -16,8 +16,8 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
-use crate::xor_linked_list::XorLinkedListOps;
 use crate::unchecked_option::UncheckedOptionExt;
+use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
 
 // =============================================================================

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -22,6 +22,7 @@ use crate::link_ops::{self, DefaultLinkOps};
 use crate::linked_list::LinkedListOps;
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
+use crate::unchecked_option::UncheckedOptionExt;
 use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
 use crate::KeyAdapter;

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1190,6 +1190,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+
+    use crate::UnsafeRef;
+
     use super::{Link, SinglyLinkedList};
     use std::fmt;
     use std::format;
@@ -1206,23 +1210,28 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(ObjAdapter1 = Rc<Obj>: Obj { link1: Link });
-    intrusive_adapter!(ObjAdapter2 = Rc<Obj>: Obj { link2: Link });
-    fn make_obj(value: u32) -> Rc<Obj> {
-        Rc::new(Obj {
+    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1: Link });
+    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2: Link });
+    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1: Link });
+
+    fn make_rc_obj(value: u32) -> Rc<Obj> {
+        Rc::new(make_obj(value))
+    }
+    fn make_obj(value: u32) -> Obj {
+        Obj {
             link1: Link::new(),
             link2: Link::default(),
             value,
-        })
+        }
     }
 
     #[test]
     fn test_link() {
-        let a = make_obj(1);
+        let a = make_rc_obj(1);
         assert!(!a.link1.is_linked());
         assert!(!a.link2.is_linked());
 
-        let mut b = SinglyLinkedList::<ObjAdapter1>::default();
+        let mut b = SinglyLinkedList::<RcObjAdapter1>::default();
         assert!(b.is_empty());
 
         b.push_front(a.clone());
@@ -1243,11 +1252,11 @@ mod tests {
 
     #[test]
     fn test_cursor() {
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
 
-        let mut l = SinglyLinkedList::new(ObjAdapter1::new());
+        let mut l = SinglyLinkedList::new(RcObjAdapter1::new());
         let mut cur = l.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
@@ -1324,14 +1333,14 @@ mod tests {
 
     #[test]
     fn test_split_splice() {
-        let mut l1 = SinglyLinkedList::new(ObjAdapter1::new());
-        let mut l2 = SinglyLinkedList::new(ObjAdapter1::new());
-        let mut l3 = SinglyLinkedList::new(ObjAdapter1::new());
+        let mut l1 = SinglyLinkedList::new(RcObjAdapter1::new());
+        let mut l2 = SinglyLinkedList::new(RcObjAdapter1::new());
+        let mut l3 = SinglyLinkedList::new(RcObjAdapter1::new());
 
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l1.cursor_mut().insert_after(d);
         l1.cursor_mut().insert_after(c);
         l1.cursor_mut().insert_after(b);
@@ -1417,11 +1426,11 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        let mut l = SinglyLinkedList::new(ObjAdapter1::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let mut l = SinglyLinkedList::new(RcObjAdapter1::new());
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l.cursor_mut().insert_after(d.clone());
         l.cursor_mut().insert_after(c.clone());
         l.cursor_mut().insert_after(b.clone());
@@ -1471,12 +1480,12 @@ mod tests {
 
     #[test]
     fn test_multi_list() {
-        let mut l1 = SinglyLinkedList::new(ObjAdapter1::new());
-        let mut l2 = SinglyLinkedList::new(ObjAdapter2::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let mut l1 = SinglyLinkedList::new(RcObjAdapter1::new());
+        let mut l2 = SinglyLinkedList::new(RcObjAdapter2::new());
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l1.cursor_mut().insert_after(d.clone());
         l1.cursor_mut().insert_after(c.clone());
         l1.cursor_mut().insert_after(b.clone());
@@ -1490,29 +1499,39 @@ mod tests {
     }
 
     #[test]
-    fn test_fast_clear() {
-        let mut l = SinglyLinkedList::new(ObjAdapter1::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
+    fn test_fast_clear_force_unlink() {
+        let mut l = SinglyLinkedList::new(UnsafeRefObjAdapter1::new());
+        let a = UnsafeRef::from_box(Box::new(make_obj(1)));
+        let b = UnsafeRef::from_box(Box::new(make_obj(2)));
+        let c = UnsafeRef::from_box(Box::new(make_obj(3)));
         l.cursor_mut().insert_after(a.clone());
         l.cursor_mut().insert_after(b.clone());
         l.cursor_mut().insert_after(c.clone());
 
         l.fast_clear();
         assert!(l.is_empty());
-        assert!(a.link1.is_linked());
-        assert!(b.link1.is_linked());
-        assert!(c.link1.is_linked());
+
         unsafe {
+            assert!(a.link1.is_linked());
+            assert!(b.link1.is_linked());
+            assert!(c.link1.is_linked());
+
             a.link1.force_unlink();
             b.link1.force_unlink();
             c.link1.force_unlink();
+
+            assert!(l.is_empty());
+
+            assert!(!a.link1.is_linked());
+            assert!(!b.link1.is_linked());
+            assert!(!c.link1.is_linked());
         }
-        assert!(l.is_empty());
-        assert!(!a.link1.is_linked());
-        assert!(!b.link1.is_linked());
-        assert!(!c.link1.is_linked());
+
+        unsafe {
+            UnsafeRef::into_box(a);
+            UnsafeRef::into_box(b);
+            UnsafeRef::into_box(c);
+        }
     }
 
     #[test]

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -19,7 +19,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
-use crate::unchecked_option::UncheckedOptionExt;
 use crate::Adapter;
 
 // =============================================================================
@@ -1616,6 +1615,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::UnsafeRef;
+
     use super::{Link, XorLinkedList};
     use core::cell::Cell;
     use core::ptr;
@@ -1635,24 +1636,29 @@ mod tests {
             write!(f, "{}", self.value)
         }
     }
-    intrusive_adapter!(ObjAdapter1 = Rc<Obj>: Obj { link1: Link });
-    intrusive_adapter!(ObjAdapter2 = Rc<Obj>: Obj { link2: Link });
+    intrusive_adapter!(RcObjAdapter1 = Rc<Obj>: Obj { link1: Link });
+    intrusive_adapter!(RcObjAdapter2 = Rc<Obj>: Obj { link2: Link });
+    intrusive_adapter!(UnsafeRefObjAdapter1 = UnsafeRef<Obj>: Obj { link1: Link });
 
-    fn make_obj(value: u32) -> Rc<Obj> {
-        Rc::new(Obj {
+    fn make_rc_obj(value: u32) -> Rc<Obj> {
+        Rc::new(make_obj(value))
+    }
+
+    fn make_obj(value: u32) -> Obj {
+        Obj {
             link1: Link::new(),
             link2: Link::default(),
             value,
-        })
+        }
     }
 
     #[test]
     fn test_link() {
-        let a = make_obj(1);
+        let a = make_rc_obj(1);
         assert!(!a.link1.is_linked());
         assert!(!a.link2.is_linked());
 
-        let mut b = XorLinkedList::<ObjAdapter1>::default();
+        let mut b = XorLinkedList::<RcObjAdapter1>::default();
         assert!(b.is_empty());
 
         b.cursor_mut().insert_after(a.clone());
@@ -1673,11 +1679,11 @@ mod tests {
 
     #[test]
     fn test_cursor() {
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
 
-        let mut l = XorLinkedList::new(ObjAdapter1::new());
+        let mut l = XorLinkedList::new(RcObjAdapter1::new());
         let mut cur = l.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
@@ -1756,11 +1762,11 @@ mod tests {
 
     #[test]
     fn test_push_pop() {
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
 
-        let mut l = XorLinkedList::new(ObjAdapter1::new());
+        let mut l = XorLinkedList::new(RcObjAdapter1::new());
         l.push_front(a);
         assert_eq!(l.iter().map(|x| x.value).collect::<Vec<_>>(), [1]);
         l.push_front(b);
@@ -1781,14 +1787,14 @@ mod tests {
 
     #[test]
     fn test_split_splice() {
-        let mut l1 = XorLinkedList::new(ObjAdapter1::new());
-        let mut l2 = XorLinkedList::new(ObjAdapter1::new());
-        let mut l3 = XorLinkedList::new(ObjAdapter1::new());
+        let mut l1 = XorLinkedList::new(RcObjAdapter1::new());
+        let mut l2 = XorLinkedList::new(RcObjAdapter1::new());
+        let mut l3 = XorLinkedList::new(RcObjAdapter1::new());
 
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l1.cursor_mut().insert_before(a);
         l1.cursor_mut().insert_before(b);
         l1.cursor_mut().insert_before(c);
@@ -1872,11 +1878,11 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        let mut l = XorLinkedList::new(ObjAdapter1::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let mut l = XorLinkedList::new(RcObjAdapter1::new());
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l.cursor_mut().insert_before(a.clone());
         l.cursor_mut().insert_before(b.clone());
         l.cursor_mut().insert_before(c.clone());
@@ -1979,12 +1985,12 @@ mod tests {
 
     #[test]
     fn test_multi_list() {
-        let mut l1 = XorLinkedList::new(ObjAdapter1::new());
-        let mut l2 = XorLinkedList::new(ObjAdapter2::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
-        let d = make_obj(4);
+        let mut l1 = XorLinkedList::new(RcObjAdapter1::new());
+        let mut l2 = XorLinkedList::new(RcObjAdapter2::new());
+        let a = make_rc_obj(1);
+        let b = make_rc_obj(2);
+        let c = make_rc_obj(3);
+        let d = make_rc_obj(4);
         l1.cursor_mut().insert_before(a.clone());
         l1.cursor_mut().insert_before(b.clone());
         l1.cursor_mut().insert_before(c.clone());
@@ -1998,46 +2004,56 @@ mod tests {
     }
 
     #[test]
-    fn test_force_unlink() {
-        let mut l = XorLinkedList::new(ObjAdapter1::new());
-        let a = make_obj(1);
-        let b = make_obj(2);
-        let c = make_obj(3);
+    fn test_fast_clear_force_unlink() {
+        let mut l = XorLinkedList::new(UnsafeRefObjAdapter1::new());
+        let a = UnsafeRef::from_box(Box::new(make_obj(1)));
+        let b = UnsafeRef::from_box(Box::new(make_obj(2)));
+        let c = UnsafeRef::from_box(Box::new(make_obj(3)));
         l.cursor_mut().insert_before(a.clone());
         l.cursor_mut().insert_before(b.clone());
         l.cursor_mut().insert_before(c.clone());
 
         l.fast_clear();
         assert!(l.is_empty());
-        assert!(a.link1.is_linked());
-        assert!(b.link1.is_linked());
-        assert!(c.link1.is_linked());
+
         unsafe {
+            assert!(a.link1.is_linked());
+            assert!(b.link1.is_linked());
+            assert!(c.link1.is_linked());
+
             a.link1.force_unlink();
             b.link1.force_unlink();
             c.link1.force_unlink();
+
+            assert!(l.is_empty());
+
+            assert!(!a.link1.is_linked());
+            assert!(!b.link1.is_linked());
+            assert!(!c.link1.is_linked());
         }
-        assert!(l.is_empty());
-        assert!(!a.link1.is_linked());
-        assert!(!b.link1.is_linked());
-        assert!(!c.link1.is_linked());
+
+        unsafe {
+            UnsafeRef::into_box(a);
+            UnsafeRef::into_box(b);
+            UnsafeRef::into_box(c);
+        }
     }
 
     #[test]
     fn test_reverse() {
-        let mut l = XorLinkedList::new(ObjAdapter1::new());
+        let mut l = XorLinkedList::new(RcObjAdapter1::new());
 
-        l.push_back(make_obj(1));
-        l.push_back(make_obj(2));
-        l.push_back(make_obj(3));
-        l.push_back(make_obj(4));
+        l.push_back(make_rc_obj(1));
+        l.push_back(make_rc_obj(2));
+        l.push_back(make_rc_obj(3));
+        l.push_back(make_rc_obj(4));
         assert_eq!(l.iter().map(|x| x.value).collect::<Vec<_>>(), [1, 2, 3, 4]);
 
         l.reverse();
         assert_eq!(l.iter().map(|x| x.value).collect::<Vec<_>>(), [4, 3, 2, 1]);
 
-        l.push_back(make_obj(5));
-        l.push_back(make_obj(6));
+        l.push_back(make_rc_obj(5));
+        l.push_back(make_rc_obj(6));
         assert_eq!(
             l.iter().map(|x| x.value).collect::<Vec<_>>(),
             [4, 3, 2, 1, 5, 6]

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -19,6 +19,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
+use crate::unchecked_option::UncheckedOptionExt;
 use crate::Adapter;
 
 // =============================================================================


### PR DESCRIPTION
Fixed issue in #81 (detected by Miri) by switching to a combination of `UnsafeRef` and `Box` instead of `Rc`. Renamed each of the failing tests to `test_fast_clear_force_unlink` to better indicate that they test the same behavior.