### PR TITLE
Add Miri to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         command: test
         args: --features nightly
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -42,3 +41,15 @@ jobs:
         with:
           command: fmt
           args: -- --check
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: rustup component add miri
+      - run: cargo miri test --verbose --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.DS_Store


### PR DESCRIPTION
With both #81 and #83 addressed, all tests pass in Miri now! Adding as a separate CI step.
