### PR TITLE
Fix soundness issue in with `UnsafeRef<T>`

### DIFF
--- a/src/unsafe_ref.rs
+++ b/src/unsafe_ref.rs
@@ -104,6 +104,6 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for UnsafeRef<T> {
     }
 }
 
-unsafe impl<T: ?Sized + Send> Send for UnsafeRef<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Send for UnsafeRef<T> {}
 
 unsafe impl<T: ?Sized + Sync> Sync for UnsafeRef<T> {}


### PR DESCRIPTION
Fixes #92. This applies a suggestion from @cramertj in an internal unsafe review.

Tested:
```
$ cargo test
  ...
    Finished test [unoptimized + debuginfo] target(s) in 6.56s
     Running unittests src/lib.rs (target/debug/deps/intrusive_collections-3ba832551695f9a4)

running 61 tests
test linked_list::tests::test_clone_pointer_arc ... ok
test linked_list::tests::test_cursor ... ok
test linked_list::tests::test_clone_pointer_rc ... ok
test linked_list::tests::test_cursor_owning ... ok
test linked_list::tests::test_fast_clear_force_unlink ... ok
test linked_list::tests::test_link ... ok
test linked_list::tests::test_multi_list ... ok
test linked_list::tests::test_iter ... ok
test linked_list::tests::test_non_static ... ok
test linked_list::tests::test_push_pop ... ok
test linked_list::tests::test_split_splice ... ok
test pointer_ops::tests::clone_arc_from_raw ... ok
test pointer_ops::tests::clone_pin_rc_from_raw ... ok
test pointer_ops::tests::clone_pin_arc_from_raw ... ok
test pointer_ops::tests::clone_rc_from_raw ... ok
test pointer_ops::tests::test_arc ... ok
test pointer_ops::tests::test_arc_unsized ... ok
test pointer_ops::tests::test_box_unsized ... ok
test pointer_ops::tests::test_pin_arc ... ok
test pointer_ops::tests::test_pin_arc_unsized ... ok
test pointer_ops::tests::test_box ... ok
test pointer_ops::tests::test_pin_box ... ok
test pointer_ops::tests::test_pin_rc ... ok
test pointer_ops::tests::test_pin_box_unsized ... ok
test pointer_ops::tests::test_pin_rc_unsized ... ok
test pointer_ops::tests::test_rc ... ok
test pointer_ops::tests::test_rc_unsized ... ok
test rbtree::tests::test_clone_pointer_arc ... ok
test rbtree::tests::test_clone_pointer_rc ... ok
test rbtree::tests::test_cursor ... ok
test rbtree::tests::test_cursor_owning ... ok
test rbtree::tests::test_entry ... ok
test rbtree::tests::test_fast_clear_force_unlink ... ok
test rbtree::tests::test_link ... ok
test singly_linked_list::tests::test_clone_pointer_arc ... ok
test rbtree::tests::test_non_static ... ok
test rbtree::tests::test_iter ... ok
test singly_linked_list::tests::test_cursor_owning ... ok
test rbtree::tests::test_find ... ok
test singly_linked_list::tests::test_cursor ... ok
test singly_linked_list::tests::test_clone_pointer_rc ... ok
test singly_linked_list::tests::test_link ... ok
test singly_linked_list::tests::test_multi_list ... ok
test xor_linked_list::tests::test_clone_pointer_arc ... ok
test singly_linked_list::tests::test_iter ... ok
test singly_linked_list::tests::test_split_splice ... ok
test singly_linked_list::tests::test_fast_clear_force_unlink ... ok
test xor_linked_list::tests::test_clone_pointer_rc ... ok
test xor_linked_list::tests::test_cursor_owning ... ok
test xor_linked_list::tests::test_cursor ... ok
test singly_linked_list::tests::test_non_static ... ok
test xor_linked_list::tests::test_fast_clear_force_unlink ... ok
test xor_linked_list::tests::test_drop ... ok
test xor_linked_list::tests::test_iter ... ok
test xor_linked_list::tests::test_multi_list ... ok
test xor_linked_list::tests::test_link ... ok
test xor_linked_list::tests::test_non_static ... ok
test xor_linked_list::tests::test_push_pop ... ok
test xor_linked_list::tests::test_reverse ... ok
test xor_linked_list::tests::test_split_splice ... ok
test rbtree::tests::test_insert_remove ... ok

test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests intrusive-collections

running 9 tests
test src/adapter.rs - adapter::intrusive_adapter (line 116) ... ignored
test src/adapter.rs - adapter::intrusive_adapter (line 127) ... ignored
test src/adapter.rs - adapter::container_of (line 85) ... ok
test src/lib.rs - (line 152) ... ok
test src/adapter.rs - adapter::intrusive_adapter (line 145) ... ok
test src/lib.rs - (line 23) ... ok
test src/lib.rs - (line 91) ... ok
test src/key_adapter.rs - key_adapter::KeyAdapter (line 21) ... ok
test src/lib.rs - (line 188) ... ok

test result: ok. 7 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.27s
```