### PR TITLE
Add a `clear_with` method to each data structure.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! use intrusive_collections::{LinkedList, LinkedListLink};
 //! use std::cell::Cell;
 //!
-//! // A simple struct containing an instrusive link and a value
+//! // A simple struct containing an intrusive link and a value
 //! struct Test {
 //!     link: LinkedListLink,
 //!     value: Cell<i32>,
@@ -61,7 +61,7 @@
 //! list.front().get().unwrap().value.set(4);
 //! assert_eq!(list.iter().map(|x| x.value.get()).collect::<Vec<_>>(), [4, 2, 1]);
 //!
-//! // Removing an object from an instrusive collection gives us back the
+//! // Removing an object from an intrusive collection gives us back the
 //! // Box<Test> that we originally inserted into it.
 //! let a = list.pop_front().unwrap();
 //! assert_eq!(a.value.get(), 4);

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1333,7 +1333,7 @@ where
 
     /// Removes all elements from the `LinkedList`.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `LinkedList`. Each element is
     /// converted back to an owned pointer and then dropped.
     #[inline]
@@ -1344,7 +1344,7 @@ where
     /// Removes all elements from the `LinkedList` and calls a function on each
     /// to handle dropping the owned pointer.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `LinkedList`. Each element is
     /// converted back to an owned pointer and then passed to the given
     /// `dropper` function.

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1338,6 +1338,21 @@ where
     /// converted back to an owned pointer and then dropped.
     #[inline]
     pub fn clear(&mut self) {
+        self.clear_with(drop);
+    }
+
+    /// Removes all elements from the `LinkedList` and calls a function on each
+    /// to handle dropping the owned pointer.
+    ///
+    /// This will unlink all object currently in the list, which requires
+    /// iterating through all elements in the `LinkedList`. Each element is
+    /// converted back to an owned pointer and then passed to the given
+    /// `dropper` function.
+    #[inline]
+    pub fn clear_with<F>(&mut self, mut dropper: F)
+    where
+        F: FnMut(<A::PointerOps as PointerOps>::Pointer),
+    {
         use link_ops::LinkOps;
 
         let mut current = self.head;
@@ -1347,9 +1362,13 @@ where
             unsafe {
                 let next = self.adapter.link_ops().next(x);
                 self.adapter.link_ops_mut().release_link(x);
-                self.adapter
-                    .pointer_ops()
-                    .from_raw(self.adapter.get_value(x));
+
+                dropper(
+                    self.adapter
+                        .pointer_ops()
+                        .from_raw(self.adapter.get_value(x)),
+                );
+
                 current = next;
             }
         }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -18,7 +18,7 @@ use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
 use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
-// Necessary for Rust 1.56 compatability
+// Necessary for Rust 1.56 compatibility
 #[allow(unused_imports)]
 use crate::unchecked_option::UncheckedOptionExt;
 
@@ -323,7 +323,7 @@ impl AtomicLink {
     ///
     /// # Safety
     ///
-    /// This can only be called after `acquire_link` has been succesfully called.
+    /// This can only be called after `acquire_link` has been successfully called.
     #[inline]
     unsafe fn next_exclusive(&self) -> &Cell<Option<NonNull<AtomicLink>>> {
         // This is safe because currently AtomicPtr<AtomicLink> has the same representation Cell<Option<NonNull<AtomicLink>>>.

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -25,7 +25,7 @@ use crate::singly_linked_list::SinglyLinkedListOps;
 use crate::xor_linked_list::XorLinkedListOps;
 use crate::Adapter;
 use crate::KeyAdapter;
-// Necessary for Rust 1.56 compatability
+// Necessary for Rust 1.56 compatibility
 #[allow(unused_imports)]
 use crate::unchecked_option::UncheckedOptionExt;
 
@@ -410,7 +410,7 @@ impl AtomicLink {
     ///
     /// # Safety
     ///
-    /// This can only be called after `acquire_link` has been succesfully called.
+    /// This can only be called after `acquire_link` has been successfully called.
     #[inline]
     unsafe fn parent_color_exclusive(&self) -> &Cell<usize> {
         // This is safe because currently AtomicUsize has the same representation Cell<usize>.

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1770,7 +1770,7 @@ where
 
     /// Removes all elements from the `RBTree`.
     ///
-    /// This will unlink all object currently in the tree, which requires
+    /// This will unlink all objects currently in the tree, which requires
     /// iterating through all elements in the `RBTree`. Each element is
     /// converted back to an owned pointer and then dropped.
     #[inline]
@@ -1781,7 +1781,7 @@ where
     /// Removes all elements from the `RBTree` and calls a function on each
     /// to handle dropping the owned pointer.
     ///
-    /// This will unlink all object currently in the tree, which requires
+    /// This will unlink all objects currently in the tree, which requires
     /// iterating through all elements in the `RBTree`. Each element is
     /// converted back to an owned pointer and then dropped.
     #[inline]

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1076,7 +1076,7 @@ where
 
     /// Removes all elements from the `SinglyLinkedList`.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `SinglyLinkedList`. Each element is
     /// converted back to an owned pointer and then dropped.
     #[inline]
@@ -1087,7 +1087,7 @@ where
     /// Removes all elements from the `SinglyLinkedList` and calls a function on
     /// each to handle dropping the owned pointer.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `SinglyLinkedList`. Each element is
     /// converted back to an owned pointer and then passed to the given
     /// `dropper` function.

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -275,7 +275,7 @@ impl AtomicLink {
     ///
     /// # Safety
     ///
-    /// This can only be called after `acquire_link` has been succesfully called.
+    /// This can only be called after `acquire_link` has been successfully called.
     #[inline]
     unsafe fn next_exclusive(&self) -> &Cell<Option<NonNull<AtomicLink>>> {
         // This is safe because currently AtomicPtr<AtomicLink> has the same representation Cell<Option<NonNull<AtomicLink>>>.

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1081,6 +1081,21 @@ where
     /// converted back to an owned pointer and then dropped.
     #[inline]
     pub fn clear(&mut self) {
+        self.clear_with(drop);
+    }
+
+    /// Removes all elements from the `SinglyLinkedList` and calls a function on
+    /// each to handle dropping the owned pointer.
+    ///
+    /// This will unlink all object currently in the list, which requires
+    /// iterating through all elements in the `SinglyLinkedList`. Each element is
+    /// converted back to an owned pointer and then passed to the given
+    /// `dropper` function.
+    #[inline]
+    pub fn clear_with<F>(&mut self, mut dropper: F)
+    where
+        F: FnMut(<A::PointerOps as PointerOps>::Pointer),
+    {
         use link_ops::LinkOps;
 
         let mut current = self.head;
@@ -1089,9 +1104,11 @@ where
             unsafe {
                 let next = self.adapter.link_ops().next(x);
                 self.adapter.link_ops_mut().release_link(x);
-                self.adapter
-                    .pointer_ops()
-                    .from_raw(self.adapter.get_value(x));
+                dropper(
+                    self.adapter
+                        .pointer_ops()
+                        .from_raw(self.adapter.get_value(x)),
+                );
                 current = next;
             }
         }

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1493,7 +1493,7 @@ where
 
     /// Removes all elements from the `XorLinkedList`.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `XorLinkedList`. Each element is
     /// converted back to an owned pointer and then dropped.
     #[inline]
@@ -1504,7 +1504,7 @@ where
     /// Removes all elements from the `XorLinkedList` and calls a function on each
     /// to handle dropping the owned pointer.
     ///
-    /// This will unlink all object currently in the list, which requires
+    /// This will unlink all objects currently in the list, which requires
     /// iterating through all elements in the `XorLinkedList`. Each element is
     /// converted back to an owned pointer and then passed to the given
     /// `dropper` function.

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -20,7 +20,7 @@ use crate::link_ops::{self, DefaultLinkOps};
 use crate::pointer_ops::PointerOps;
 use crate::singly_linked_list::SinglyLinkedListOps;
 use crate::Adapter;
-// Necessary for Rust 1.56 compatability
+// Necessary for Rust 1.56 compatibility
 #[allow(unused_imports)]
 use crate::unchecked_option::UncheckedOptionExt;
 
@@ -301,7 +301,7 @@ impl AtomicLink {
     ///
     /// # Safety
     ///
-    /// This can only be called after `acquire_link` has been succesfully called.
+    /// This can only be called after `acquire_link` has been successfully called.
     #[inline]
     unsafe fn packed_exclusive(&self) -> &Cell<usize> {
         // This is safe because currently AtomicUsize has the same representation Cell<usize>.


### PR DESCRIPTION
I have [a library](https://github.com/novacrazy/intrusive_lru_cache) that uses both the intrusive RBTree and the intrusive linked list, using `UnsafeRef` to share the node between them. However, because `UnsafeRef` doesn't implement dropping the pointer on its own, I currently use `fast_clear` on the tree and then remove the front item of the list in a loop, using `UnsafeRef::into_box` to drop it, then continue until no elements remain. 

This loop of calling `remove` is sub-optimal because it hooks up the list nodes again despite only iterating forward to drop every node.

It's also infeasible/impossible to write my own `UnsafeRef` due to the heavy reliance on `DefaultPointerOps`.

Instead, I propose a `clear_with` method to provide a function to drop the pointers with custom behavior, with the regular `clear` being implemented as simply `clear_with(drop)`. Codegen is identical in a quick test. This provides the flexibility I need while remaining fast and safe. 

So now my own `clear` method looks like this:
```rust
pub fn clear(&mut self) {
    self.tree.fast_clear();

    self.list.clear_with(|node| {
        // SAFETY: Node is removed from both the tree and list
        let _ = unsafe { UnsafeRef::into_box(node) };
    });
}
```

I also fixed a handful of typos my IDE noticed. 