### PR TITLE
Add raw pointer access to cursors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,10 @@
 //! `CursorMut` can be used to mutate the collection, but you may only use one
 //! of them at a time.
 //!
+//! Use `get` to access the current element by reference, or `get_ptr` to obtain
+//! the raw pointer for pointer identity or FFI interop. Both return `None` when
+//! the cursor is pointing at the null position.
+//!
 //! Cursors are a very powerful abstraction since they allow a collection to be
 //! mutated safely while it is being iterated on. For example, here is a
 //! function which removes all values within a given range from a `RBTree`:

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -625,6 +625,16 @@ where
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
     }
 
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    }
+
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
@@ -722,6 +732,16 @@ where
     #[inline]
     pub fn get(&self) -> Option<&<A::PointerOps as PointerOps>::Value> {
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
+
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1655,6 +1675,7 @@ mod tests {
         let mut cur = l.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
+        assert!(cur.get_ptr().is_none());
         assert!(cur.remove().is_none());
         assert_eq!(
             cur.replace_with(a.clone()).unwrap_err().as_ref() as *const _,
@@ -1673,16 +1694,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -1690,8 +1714,10 @@ mod tests {
             cur2.move_next();
             assert!(cur2.is_null());
             assert!(cur2.clone().get().is_none());
+            assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         cur.move_next();
         assert_eq!(
@@ -1699,10 +1725,12 @@ mod tests {
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
         cur.move_prev();
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
         assert_eq!(
             cur.remove().unwrap().as_ref() as *const _,
             a.as_ref() as *const _
@@ -1710,6 +1738,7 @@ mod tests {
         assert!(!a.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
         assert_eq!(
             cur.replace_with(a.clone()).unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1717,6 +1746,7 @@ mod tests {
         assert!(a.link1.is_linked());
         assert!(!c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
         cur.move_next();
         assert_eq!(
             cur.replace_with(c.clone()).unwrap().as_ref() as *const _,

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -631,8 +631,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Clones and returns the pointer that points to the element that the
@@ -740,8 +743,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1609,6 +1615,7 @@ mod tests {
     use crate::UnsafeRef;
 
     use super::{CursorOwning, Link, LinkedList};
+    use core::ptr::NonNull;
     use std::fmt;
     use std::format;
     use std::rc::Rc;
@@ -1694,19 +1701,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(a.as_ref()));
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(c.as_ref()));
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -1717,7 +1724,7 @@ mod tests {
             assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         cur.move_next();
         assert_eq!(
@@ -1725,12 +1732,12 @@ mod tests {
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
         cur.move_prev();
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
         assert_eq!(
             cur.remove().unwrap().as_ref() as *const _,
             a.as_ref() as *const _
@@ -1738,7 +1745,7 @@ mod tests {
         assert!(!a.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
         assert_eq!(
             cur.replace_with(a.clone()).unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1746,7 +1753,7 @@ mod tests {
         assert!(a.link1.is_linked());
         assert!(!c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
         cur.move_next();
         assert_eq!(
             cur.replace_with(c.clone()).unwrap().as_ref() as *const _,

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1087,8 +1087,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.tree.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.tree.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Clones and returns the pointer that points to the element that the
@@ -1199,8 +1202,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.tree.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.tree.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -2550,6 +2556,7 @@ mod tests {
     use super::{CursorOwning, Entry, KeyAdapter, Link, PointerOps, RBTree};
     use crate::{Bound::*, UnsafeRef};
     use alloc::boxed::Box;
+    use core::ptr::NonNull;
     use rand::prelude::*;
     use rand_xorshift::XorShiftRng;
     use std::fmt;
@@ -2650,19 +2657,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(a.as_ref()));
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(c.as_ref()));
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -2673,7 +2680,7 @@ mod tests {
             assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         let a2 = make_rc_obj(1);
         let b2 = make_rc_obj(2);

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1081,6 +1081,16 @@ where
         Some(unsafe { &*self.tree.adapter.get_value(self.current?) })
     }
 
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.tree.adapter.get_value(self.current?) })
+    }
+
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
@@ -1181,6 +1191,16 @@ where
     #[inline]
     pub fn get(&self) -> Option<&<A::PointerOps as PointerOps>::Value> {
         Some(unsafe { &*self.tree.adapter.get_value(self.current?) })
+    }
+
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.tree.adapter.get_value(self.current?) })
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -2615,6 +2635,7 @@ mod tests {
         let mut cur = t.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
+        assert!(cur.get_ptr().is_none());
         assert!(cur.remove().is_none());
 
         cur.insert_before(a.clone());
@@ -2629,16 +2650,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -2646,8 +2670,10 @@ mod tests {
             cur2.move_next();
             assert!(cur2.is_null());
             assert!(cur2.clone().get().is_none());
+            assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         let a2 = make_rc_obj(1);
         let b2 = make_rc_obj(2);

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -542,6 +542,16 @@ where
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
     }
 
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    }
+
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
@@ -613,6 +623,16 @@ where
     #[inline]
     pub fn get(&self) -> Option<&<A::PointerOps as PointerOps>::Value> {
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
+
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1349,6 +1369,7 @@ mod tests {
         let mut cur = l.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
+        assert!(cur.get_ptr().is_none());
         assert!(cur.remove_next().is_none());
         assert_eq!(
             cur.replace_next_with(a.clone()).unwrap_err().as_ref() as *const _,
@@ -1368,30 +1389,37 @@ mod tests {
         cur.move_next();
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
             cur2.move_next();
             assert!(cur2.is_null());
             assert!(cur2.clone().get().is_none());
+            assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         assert_eq!(
             cur.remove_next().unwrap().as_ref() as *const _,
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
         cur.move_next();
         assert_eq!(cur.get().unwrap() as *const _, b.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), b.as_ref() as *const _);
         assert_eq!(
             cur.remove_next().unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1399,6 +1427,7 @@ mod tests {
         assert!(!c.link1.is_linked());
         assert!(a.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, b.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), b.as_ref() as *const _);
         cur.move_next();
         assert!(cur.is_null());
         assert_eq!(
@@ -1410,6 +1439,7 @@ mod tests {
         assert!(cur.is_null());
         cur.move_next();
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
         assert_eq!(
             cur.replace_next_with(a.clone()).unwrap().as_ref() as *const _,
             b.as_ref() as *const _
@@ -1418,6 +1448,7 @@ mod tests {
         assert!(!b.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
     }
 
     #[test]

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -548,8 +548,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Clones and returns the pointer that points to the element that the
@@ -631,8 +634,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1304,6 +1310,7 @@ mod tests {
     use crate::UnsafeRef;
 
     use super::{CursorOwning, Link, SinglyLinkedList};
+    use core::ptr::NonNull;
     use std::fmt;
     use std::format;
     use std::rc::Rc;
@@ -1389,37 +1396,37 @@ mod tests {
         cur.move_next();
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(a.as_ref()));
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(c.as_ref()));
             cur2.move_next();
             assert!(cur2.is_null());
             assert!(cur2.clone().get().is_none());
             assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         assert_eq!(
             cur.remove_next().unwrap().as_ref() as *const _,
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
         cur.move_next();
         assert_eq!(cur.get().unwrap() as *const _, b.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), b.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(b.as_ref()));
         assert_eq!(
             cur.remove_next().unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1427,7 +1434,7 @@ mod tests {
         assert!(!c.link1.is_linked());
         assert!(a.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, b.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), b.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(b.as_ref()));
         cur.move_next();
         assert!(cur.is_null());
         assert_eq!(
@@ -1439,7 +1446,7 @@ mod tests {
         assert!(cur.is_null());
         cur.move_next();
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
         assert_eq!(
             cur.replace_next_with(a.clone()).unwrap().as_ref() as *const _,
             b.as_ref() as *const _
@@ -1448,7 +1455,7 @@ mod tests {
         assert!(!b.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
     }
 
     #[test]

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -514,6 +514,16 @@ where
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
     }
 
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    }
+
     /// Clones and returns the pointer that points to the element that the
     /// cursor is referencing.
     ///
@@ -625,6 +635,16 @@ where
     #[inline]
     pub fn get(&self) -> Option<&<A::PointerOps as PointerOps>::Value> {
         Some(unsafe { &*self.list.adapter.get_value(self.current?) })
+    }
+
+    /// Returns a raw pointer to the object that the cursor is currently
+    /// pointing to.
+    ///
+    /// This returns `None` if the cursor is currently pointing to the null
+    /// object.
+    #[inline]
+    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
+        Some(unsafe { self.list.adapter.get_value(self.current?) })
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1838,6 +1858,7 @@ mod tests {
         let mut cur = l.cursor_mut();
         assert!(cur.is_null());
         assert!(cur.get().is_none());
+        assert!(cur.get_ptr().is_none());
         assert!(cur.remove().is_none());
         assert_eq!(
             cur.replace_with(a.clone()).unwrap_err().as_ref() as *const _,
@@ -1856,16 +1877,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -1873,8 +1897,10 @@ mod tests {
             cur2.move_next();
             assert!(cur2.is_null());
             assert!(cur2.clone().get().is_none());
+            assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
 
         cur.move_next();
         assert_eq!(
@@ -1882,10 +1908,12 @@ mod tests {
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
         cur.move_prev();
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
         assert_eq!(
             cur.remove().unwrap().as_ref() as *const _,
             a.as_ref() as *const _
@@ -1893,6 +1921,7 @@ mod tests {
         assert!(!a.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
         assert_eq!(
             cur.replace_with(a.clone()).unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1900,6 +1929,7 @@ mod tests {
         assert!(a.link1.is_linked());
         assert!(!c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
         cur.move_next();
         assert_eq!(
             cur.replace_with(c.clone()).unwrap().as_ref() as *const _,
@@ -1909,6 +1939,7 @@ mod tests {
         assert!(!b.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
     }
 
     #[test]

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -520,8 +520,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Clones and returns the pointer that points to the element that the
@@ -643,8 +646,11 @@ where
     /// This returns `None` if the cursor is currently pointing to the null
     /// object.
     #[inline]
-    pub fn get_ptr(&self) -> Option<*const <A::PointerOps as PointerOps>::Value> {
-        Some(unsafe { self.list.adapter.get_value(self.current?) })
+    pub fn get_ptr(&self) -> Option<NonNull<<A::PointerOps as PointerOps>::Value>> {
+        unsafe {
+            let ptr = self.list.adapter.get_value(self.current?);
+            Some(NonNull::new_unchecked(ptr.cast_mut()))
+        }
     }
 
     /// Returns a read-only cursor pointing to the current element.
@@ -1791,6 +1797,7 @@ mod tests {
     use super::{CursorOwning, Link, XorLinkedList};
     use core::cell::Cell;
     use core::ptr;
+    use core::ptr::NonNull;
     use std::boxed::Box;
     use std::fmt;
     use std::format;
@@ -1877,19 +1884,19 @@ mod tests {
         assert!(cur.peek_prev().is_null());
         assert!(!cur.is_null());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         {
             let mut cur2 = cur.as_cursor();
             assert_eq!(cur2.get().unwrap() as *const _, a.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), a.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(a.as_ref()));
             assert_eq!(cur2.peek_next().get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.get().unwrap().value, 2);
             cur2.move_next();
             assert_eq!(cur2.peek_prev().get().unwrap().value, 2);
             assert_eq!(cur2.get().unwrap() as *const _, c.as_ref() as *const _);
-            assert_eq!(cur2.get_ptr().unwrap(), c.as_ref() as *const _);
+            assert_eq!(cur2.get_ptr().unwrap(), NonNull::from(c.as_ref()));
             cur2.move_prev();
             assert_eq!(cur2.get().unwrap() as *const _, b.as_ref() as *const _);
             cur2.move_next();
@@ -1900,7 +1907,7 @@ mod tests {
             assert!(cur2.get_ptr().is_none());
         }
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
 
         cur.move_next();
         assert_eq!(
@@ -1908,12 +1915,12 @@ mod tests {
             b.as_ref() as *const _
         );
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
         cur.insert_after(b.clone());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
         cur.move_prev();
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
         assert_eq!(
             cur.remove().unwrap().as_ref() as *const _,
             a.as_ref() as *const _
@@ -1921,7 +1928,7 @@ mod tests {
         assert!(!a.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
         assert_eq!(
             cur.replace_with(a.clone()).unwrap().as_ref() as *const _,
             c.as_ref() as *const _
@@ -1929,7 +1936,7 @@ mod tests {
         assert!(a.link1.is_linked());
         assert!(!c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, a.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), a.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(a.as_ref()));
         cur.move_next();
         assert_eq!(
             cur.replace_with(c.clone()).unwrap().as_ref() as *const _,
@@ -1939,7 +1946,7 @@ mod tests {
         assert!(!b.link1.is_linked());
         assert!(c.link1.is_linked());
         assert_eq!(cur.get().unwrap() as *const _, c.as_ref() as *const _);
-        assert_eq!(cur.get_ptr().unwrap(), c.as_ref() as *const _);
+        assert_eq!(cur.get_ptr().unwrap(), NonNull::from(c.as_ref()));
     }
 
     #[test]


### PR DESCRIPTION
The rationale for exposing raw pointer access to those collections is to enable more flexible control over custom-sized objects.

Consider a custom struct managing pages:
```rust
#[repr(C, align(4096))]
struct PageHeader {
    link: LinkedListLink
    ...
}

struct Page(NonNull<PageHeader>, PhantomData<PageHeader>);
// Drop, fn as_ref(&self) -> PageRef<'_> implementations

struct PageRef<'a>(NonNull<PageHeader>, PhantomData<&'a PageHeader>);

struct PageAdapter { ... }
// Custom impl:
// Adapter { PointerOps = { Value = PageHeader, Pointer = Page }, ... }
```

Managing a linked list of pages via the cursor needs to reconstruct `PageRef` to obtain the full provenance of the whole page. However, the current implementation of cursors only exposes references to `PageHender`, limiting the provenance to only the header upon dereferencing the pointer. Trying to access the remaining data on the target page would result in an error in Miri. Such a limitation can be eliminated by exposing raw pointer access.

```rust
const OFF: usize = 123; // Byte offset within the page, but outside the header.

// Carries the provenance of only `PageHeader` instead of the entire page
let r: &PageHeader = cursor.get().unwrap();
// Undefined behavior / Error from Miri
unsafe { core::ptr::write((&r as *const _).byte_add(OFF) as *mut u8) };

// Carries the provenance of the entire page
let p: *const PageHeader = cursor.get_ptr().unwrap();
// Safe and sound
unsafe { core::ptr::write(p.byte_add(OFF) as *mut u8) };
// Or encapsulate more operations with wrapper types
let r: PageRef<'cursor> = unsafe { PageRef::from_raw(p) };
```