### PR TITLE
Implement Send & Sync for IntoIter of all container types

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1577,6 +1577,22 @@ where
         self.list.pop_back()
     }
 }
+// Allow sending to another thread if the ownership of the container can be
+// transferred to another thread.
+unsafe impl<A: Adapter> Send for IntoIter<A>
+where
+    LinkedList<A>: Send,
+    A::LinkOps: LinkedListOps,
+{
+}
+// Allow read-only access to values from multiple threads since IntoIter is
+// essentially a wrapper around the container so similar rules apply.
+unsafe impl<A: Adapter> Sync for IntoIter<A>
+where
+    LinkedList<A>: Sync,
+    A::LinkOps: LinkedListOps,
+{
+}
 
 // =============================================================================
 // Tests

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -2520,6 +2520,22 @@ where
         }
     }
 }
+// Allow sending to another thread if the ownership of the containing
+// RBTree can be transferred to another thread.
+unsafe impl<A: Adapter> Send for IntoIter<A>
+where
+    RBTree<A>: Send,
+    A::LinkOps: RBTreeOps,
+{
+}
+// Allow read-only access to values from multiple threads since IntoIter is
+// essentially a wrapper around the RBTree so similar rules apply.
+unsafe impl<A: Adapter> Sync for IntoIter<A>
+where
+    RBTree<A>: Sync,
+    A::LinkOps: RBTreeOps,
+{
+}
 
 // =============================================================================
 // Tests

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1272,6 +1272,22 @@ where
         self.list.pop_front()
     }
 }
+// Allow sending to another thread if the ownership of the container can be
+// transferred to another thread.
+unsafe impl<A: Adapter> Send for IntoIter<A>
+where
+    SinglyLinkedList<A>: Send,
+    A::LinkOps: SinglyLinkedListOps,
+{
+}
+// Allow read-only access to values from multiple threads since IntoIter is
+// essentially a wrapper around the container so similar rules apply.
+unsafe impl<A: Adapter> Sync for IntoIter<A>
+where
+    SinglyLinkedList<A>: Sync,
+    A::LinkOps: SinglyLinkedListOps,
+{
+}
 
 // =============================================================================
 // Tests

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1759,6 +1759,22 @@ where
         self.list.pop_back()
     }
 }
+// Allow sending to another thread if the ownership of the container can be
+// transferred to another thread.
+unsafe impl<A: Adapter> Send for IntoIter<A>
+where
+    XorLinkedList<A>: Send,
+    A::LinkOps: XorLinkedListOps,
+{
+}
+// Allow read-only access to values from multiple threads since IntoIter is
+// essentially a wrapper around the container so similar rules apply.
+unsafe impl<A: Adapter> Sync for IntoIter<A>
+where
+    XorLinkedList<A>: Sync,
+    A::LinkOps: XorLinkedListOps,
+{
+}
 
 // =============================================================================
 // Tests


### PR DESCRIPTION
Since IntoIter is essentially a wrapper around the container that pops out and returns every element, if ownership of the objects in the container can be transferred among threads, so can the struct IntoIter.

Similarly, Sync can be implemented as well.

Check #96 