### PR TITLE
Fix double free when dropping `LinkedList` returned from `CursorMut::split_before`

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1032,7 +1032,7 @@ where
                     adapter: self.list.adapter.clone(),
                 };
                 if let Some(tail) = list.tail {
-                    self.list.adapter.link_ops_mut().set_prev(tail, None);
+                    self.list.adapter.link_ops_mut().set_next(tail, None);
                 } else {
                     list.head = None;
                 }


### PR DESCRIPTION
See #99 for more info. Does not update the tests as this is a quick fix and Boxed links need to be tested more thoroughly.