### PR TITLE
UB fixes

### DIFF
--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -2451,7 +2451,6 @@ where
         use link_ops::LinkOps;
 
         let head = self.head?;
-        let is_tail = Some(head) == self.tail;
         let link_ops = self.tree.adapter.link_ops_mut();
         unsafe {
             let parent = link_ops.parent(head);
@@ -2469,13 +2468,13 @@ where
             if let Some(right) = right {
                 link_ops.set_parent(right, parent);
             }
-            if is_tail {
-                self.head = None;
-                self.tail = None;
-            } else if let Some(right) = right {
+            if let Some(right) = right {
                 self.head = Some(first_child(link_ops, right));
             } else {
                 self.head = parent;
+            }
+            if self.head.is_none() {
+                self.tail = None;
             }
             link_ops.release_link(head);
             Some(
@@ -2496,7 +2495,6 @@ where
         use link_ops::LinkOps;
 
         let tail = self.tail?;
-        let is_head = Some(tail) == self.head;
         let link_ops = self.tree.adapter.link_ops_mut();
         unsafe {
             let parent = link_ops.parent(tail);
@@ -2514,13 +2512,13 @@ where
             if let Some(left) = left {
                 link_ops.set_parent(left, parent);
             }
-            if is_head {
-                self.head = None;
-                self.tail = None;
-            } else if let Some(left) = left {
+            if let Some(left) = left {
                 self.tail = Some(last_child(link_ops, left));
             } else {
                 self.tail = parent;
+            }
+            if self.tail.is_none() {
+                self.head = None;
             }
             link_ops.release_link(tail);
             Some(

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -3084,6 +3084,60 @@ mod tests {
     }
 
     #[test]
+    fn into_iter_alternating_ends() {
+        fn build_tree(values: &[i32]) -> RBTree<RcObjAdapter> {
+            let mut tree = RBTree::new(RcObjAdapter::new());
+            for value in values {
+                tree.insert(make_rc_obj(*value));
+            }
+            tree
+        }
+
+        for len in 0..16 {
+            let ascending = (0..len).collect::<Vec<_>>();
+            let descending = (0..len).rev().collect::<Vec<_>>();
+            let mut zigzag = Vec::new();
+            let mut low = 0;
+            let mut high = len;
+            while low < high {
+                zigzag.push(low);
+                low += 1;
+                if low < high {
+                    high -= 1;
+                    zigzag.push(high);
+                }
+            }
+
+            let mut expected = Vec::new();
+            let mut front = 0;
+            let mut back = len;
+            while front < back {
+                back -= 1;
+                expected.push(back);
+                if front < back {
+                    expected.push(front);
+                    front += 1;
+                }
+            }
+
+            for values in [&ascending[..], &descending[..], &zigzag[..]] {
+                let mut iter = build_tree(values).into_iter();
+                let mut removed = Vec::new();
+                loop {
+                    match iter.next_back() {
+                        Some(value) => removed.push(value.value),
+                        None => break,
+                    }
+                    if let Some(value) = iter.next() {
+                        removed.push(value.value);
+                    }
+                }
+                assert_eq!(removed, expected);
+            }
+        }
+    }
+
+    #[test]
     fn test_find() {
         let v = (0..10).map(|x| make_rc_obj(x * 10)).collect::<Vec<_>>();
         let mut t = RBTree::new(RcObjAdapter::new());

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -2451,25 +2451,31 @@ where
         use link_ops::LinkOps;
 
         let head = self.head?;
+        let is_tail = Some(head) == self.tail;
         let link_ops = self.tree.adapter.link_ops_mut();
         unsafe {
+            let parent = link_ops.parent(head);
+            let right = link_ops.right(head);
+
             // Remove the node from the tree. Since head is always the
             // left-most node, we can infer the following:
             // - head.left is null.
             // - head is a left child of its parent (or the root node).
-            if let Some(parent) = link_ops.parent(head) {
-                link_ops.set_left(parent, link_ops.right(head));
+            if let Some(parent) = parent {
+                link_ops.set_left(parent, right);
             } else {
-                self.tree.root = link_ops.right(head);
-                if link_ops.right(head).is_none() {
-                    self.tail = None;
-                }
+                self.tree.root = right;
             }
-            if let Some(right) = link_ops.right(head) {
-                link_ops.set_parent(right, link_ops.parent(head));
+            if let Some(right) = right {
+                link_ops.set_parent(right, parent);
+            }
+            if is_tail {
+                self.head = None;
+                self.tail = None;
+            } else if let Some(right) = right {
                 self.head = Some(first_child(link_ops, right));
             } else {
-                self.head = link_ops.parent(head);
+                self.head = parent;
             }
             link_ops.release_link(head);
             Some(
@@ -2490,25 +2496,31 @@ where
         use link_ops::LinkOps;
 
         let tail = self.tail?;
+        let is_head = Some(tail) == self.head;
         let link_ops = self.tree.adapter.link_ops_mut();
         unsafe {
+            let parent = link_ops.parent(tail);
+            let left = link_ops.left(tail);
+
             // Remove the node from the tree. Since tail is always the
             // right-most node, we can infer the following:
             // - tail.right is null.
             // - tail is a right child of its parent (or the root node).
-            if let Some(parent) = link_ops.parent(tail) {
-                link_ops.set_right(parent, link_ops.left(tail));
+            if let Some(parent) = parent {
+                link_ops.set_right(parent, left);
             } else {
-                self.tree.root = link_ops.left(tail);
-                if link_ops.left(tail).is_none() {
-                    self.tail = None;
-                }
+                self.tree.root = left;
             }
-            if let Some(left) = link_ops.left(tail) {
-                link_ops.set_parent(left, link_ops.parent(tail));
+            if let Some(left) = left {
+                link_ops.set_parent(left, parent);
+            }
+            if is_head {
+                self.head = None;
+                self.tail = None;
+            } else if let Some(left) = left {
                 self.tail = Some(last_child(link_ops, left));
             } else {
-                self.tail = link_ops.parent(tail);
+                self.tail = parent;
             }
             link_ops.release_link(tail);
             Some(

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -3352,4 +3352,35 @@ mod tests {
     fn test_clone_pointer_arc() {
         test_clone_pointer!(Arc, std::sync::Arc);
     }
+
+    #[cfg(miri)]
+    #[test]
+    fn into_iter_next_after_next_back_uses_removed_tail() {
+        struct Obj {
+            link: Link,
+            value: i32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+        impl<'a> KeyAdapter<'a> for ObjAdapter {
+            type Key = i32;
+
+            fn get_key(&self, value: &'a Obj) -> i32 {
+                value.value
+            }
+        }
+
+        let mut tree = RBTree::new(ObjAdapter::new());
+        tree.insert(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+
+        let mut iter = tree.into_iter();
+        drop(iter.next_back().unwrap());
+
+        // UB: `IntoIter::next_back` clears `tail` when it removes the only
+        // node, but it leaves `head` pointing at that removed node. Alternating
+        // back to `next` dereferences the freed link.
+        let _ = iter.next();
+    }
 }

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -2064,6 +2064,45 @@ mod tests {
     }
 
     #[test]
+    fn splice_boundary_cases() {
+        let values =
+            |list: &XorLinkedList<RcObjAdapter1>| list.iter().map(|x| x.value).collect::<Vec<_>>();
+
+        let mut list = XorLinkedList::new(RcObjAdapter1::new());
+        for value in [1, 2, 3] {
+            list.push_back(make_rc_obj(value));
+        }
+        let mut inserted = XorLinkedList::new(RcObjAdapter1::new());
+        inserted.push_back(make_rc_obj(4));
+        inserted.push_back(make_rc_obj(5));
+        list.back_mut().splice_before(inserted);
+        assert_eq!(values(&list), [1, 2, 4, 5, 3]);
+        assert_eq!(list.back().get().unwrap().value, 3);
+        assert_eq!(
+            list.iter().rev().map(|x| x.value).collect::<Vec<_>>(),
+            [3, 5, 4, 2, 1]
+        );
+
+        let mut inserted = XorLinkedList::new(RcObjAdapter1::new());
+        inserted.push_back(make_rc_obj(6));
+        list.front_mut().splice_before(inserted);
+        assert_eq!(values(&list), [6, 1, 2, 4, 5, 3]);
+        assert_eq!(list.front().get().unwrap().value, 6);
+
+        let mut inserted = XorLinkedList::new(RcObjAdapter1::new());
+        inserted.push_back(make_rc_obj(7));
+        list.cursor_mut().splice_before(inserted);
+        assert_eq!(values(&list), [6, 1, 2, 4, 5, 3, 7]);
+        assert_eq!(list.back().get().unwrap().value, 7);
+
+        let mut inserted = XorLinkedList::new(RcObjAdapter1::new());
+        inserted.push_back(make_rc_obj(8));
+        list.cursor_mut().splice_after(inserted);
+        assert_eq!(values(&list), [8, 6, 1, 2, 4, 5, 3, 7]);
+        assert_eq!(list.front().get().unwrap().value, 8);
+    }
+
+    #[test]
     fn test_iter() {
         let mut l = XorLinkedList::new(RcObjAdapter1::new());
         let a = make_rc_obj(1);

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -2339,4 +2339,88 @@ mod tests {
     fn test_clone_pointer_arc() {
         test_clone_pointer!(Arc, std::sync::Arc);
     }
+
+    #[cfg(miri)]
+    #[test]
+    fn splice_before_head_corrupts_head_link() {
+        struct Obj {
+            link: Link,
+            value: u32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+
+        let mut list = XorLinkedList::new(ObjAdapter::new());
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 2,
+        }));
+
+        let mut inserted = XorLinkedList::new(ObjAdapter::new());
+        inserted.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 3,
+        }));
+        inserted.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 4,
+        }));
+
+        {
+            let mut cursor = list.front_mut();
+            // UB: splicing before the current head should move `list.head` to
+            // the spliced list's head. The implementation leaves `head`
+            // pointing at the old node even though that node now has a
+            // previous neighbor, so traversal reconstructs and dereferences a
+            // bogus XOR pointer.
+            cursor.splice_before(inserted);
+        }
+
+        let _ = list.iter().map(|x| x.value).collect::<Vec<_>>();
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn splice_before_null_corrupts_tail_link() {
+        struct Obj {
+            link: Link,
+            value: u32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+
+        let mut list = XorLinkedList::new(ObjAdapter::new());
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 2,
+        }));
+
+        let mut inserted = XorLinkedList::new(ObjAdapter::new());
+        inserted.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 3,
+        }));
+        inserted.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 4,
+        }));
+
+        {
+            let mut cursor = list.cursor_mut();
+            // UB: splicing before the null cursor means appending to the
+            // non-empty list. The implementation overwrites `head` instead of
+            // updating `tail`, making the new head encode a non-null previous
+            // pointer. Iteration then materializes and dereferences an invalid
+            // pointer.
+            cursor.splice_before(inserted);
+        }
+
+        let _ = list.iter().map(|x| x.value).collect::<Vec<_>>();
+    }
 }

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -464,6 +464,28 @@ unsafe fn link_between<T: XorLinkedListOps>(
     link_ops.set(ptr, prev, next);
 }
 
+/// Splices the non-empty range from `start` to `end` between `prev` and `next`.
+///
+/// This only rewires the XOR links. Callers must update list endpoints and
+/// cursor state separately.
+#[inline]
+unsafe fn splice_between<T: XorLinkedListOps>(
+    link_ops: &mut T,
+    start: T::LinkPtr,
+    end: T::LinkPtr,
+    prev: Option<T::LinkPtr>,
+    next: Option<T::LinkPtr>,
+) {
+    if let Some(prev) = prev {
+        link_ops.replace_next_or_prev(prev, next, Some(start));
+    }
+    if let Some(next) = next {
+        link_ops.replace_next_or_prev(next, prev, Some(end));
+    }
+    link_ops.replace_next_or_prev(start, None, prev);
+    link_ops.replace_next_or_prev(end, None, next);
+}
+
 // =============================================================================
 // Cursor, CursorMut, CursorOwning
 // =============================================================================
@@ -913,24 +935,18 @@ where
 
                 let link_ops = self.list.adapter.link_ops_mut();
 
-                if let Some(current) = self.current {
-                    if let Some(next) = self.next {
-                        link_ops.replace_next_or_prev(next, Some(current), Some(tail));
-                        link_ops.replace_next_or_prev(tail, None, Some(next));
-                    }
-                    link_ops.replace_next_or_prev(head, None, Some(current));
+                splice_between(link_ops, head, tail, self.current, self.next);
+                if self.current.is_some() {
                     self.next = list.head;
-                    link_ops.set(current, self.prev, self.next);
                 } else {
-                    if let Some(x) = self.list.head {
-                        link_ops.replace_next_or_prev(tail, None, Some(x));
-                        link_ops.replace_next_or_prev(x, None, Some(tail));
-                    }
                     self.list.head = list.head;
-                    self.next = list.head;
                 }
                 if self.list.tail == self.current {
                     self.list.tail = list.tail;
+                }
+                if self.current.is_none() {
+                    self.prev = self.list.tail;
+                    self.next = self.list.head;
                 }
                 list.head = None;
                 list.tail = None;
@@ -951,26 +967,17 @@ where
 
                 let link_ops = self.list.adapter.link_ops_mut();
 
-                if let Some(current) = self.current {
-                    if let Some(prev) = self.prev {
-                        link_ops.replace_next_or_prev(prev, Some(current), Some(head));
-                        link_ops.replace_next_or_prev(head, None, Some(prev));
-                    }
-                    link_ops.replace_next_or_prev(tail, None, Some(current));
+                splice_between(link_ops, head, tail, self.prev, self.current);
+                if self.current.is_some() {
                     self.prev = list.tail;
-                    link_ops.set(current, self.prev, self.next);
                 } else {
-                    if let Some(x) = self.list.tail {
-                        link_ops.replace_next_or_prev(head, None, Some(x));
-                        link_ops.replace_next_or_prev(x, None, Some(head));
-                    }
                     self.list.tail = list.tail;
-                    self.prev = self.list.tail;
                 }
                 if self.list.head == self.current {
                     self.list.head = list.head;
                 }
                 if self.current.is_none() {
+                    self.prev = self.list.tail;
                     self.next = self.list.head;
                 }
                 list.head = None;

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -964,11 +964,14 @@ where
                         link_ops.replace_next_or_prev(head, None, Some(x));
                         link_ops.replace_next_or_prev(x, None, Some(head));
                     }
-                    self.list.head = list.head;
-                    self.next = list.head;
-                }
-                if self.list.tail == self.current {
                     self.list.tail = list.tail;
+                    self.prev = self.list.tail;
+                }
+                if self.list.head == self.current {
+                    self.list.head = list.head;
+                }
+                if self.current.is_none() {
+                    self.next = self.list.head;
                 }
                 list.head = None;
                 list.tail = None;


### PR DESCRIPTION
The first commit adds unit tests that cause miri to report UB. The issues were discovered by GPT-5.5 xhigh.

The second and third commit apply targeted fixes.

The 4th commit refactors splice_before/after and fixes a non-memory safety issue. It can be discarded if reviewing it is burdensome.

The 5th commit adds more unit tests to exercise the changed code and gain more confidence in its correctness.

The code changes were also assisted by GPT-5.5 xhigh.