### PR TITLE
Fix UB from data races

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -316,15 +316,17 @@ impl AtomicLink {
             .store(ATOMIC_UNLINKED_MARKER_PTR, Ordering::Release)
     }
 
-    /// Access the `next` pointer in an exclusive context.
-    ///
-    /// # Safety
-    ///
-    /// This can only be called after `acquire_link` has been succesfully called.
     #[inline]
-    unsafe fn next_exclusive(&self) -> &Cell<Option<NonNull<AtomicLink>>> {
-        // This is safe because currently AtomicPtr<AtomicLink> has the same representation Cell<Option<NonNull<AtomicLink>>>.
-        core::mem::transmute(&self.next)
+    fn next(&self) -> Option<NonNull<AtomicLink>> {
+        NonNull::new(self.next.load(Ordering::Relaxed))
+    }
+
+    #[inline]
+    fn set_next(&self, next: Option<NonNull<AtomicLink>>) {
+        self.next.store(
+            next.map(|x| x.as_ptr()).unwrap_or(null_mut()),
+            Ordering::Relaxed,
+        );
     }
 }
 
@@ -404,7 +406,7 @@ unsafe impl link_ops::LinkOps for AtomicLinkOps {
 unsafe impl LinkedListOps for AtomicLinkOps {
     #[inline]
     unsafe fn next(&self, ptr: Self::LinkPtr) -> Option<Self::LinkPtr> {
-        ptr.as_ref().next_exclusive().get()
+        ptr.as_ref().next()
     }
 
     #[inline]
@@ -414,7 +416,7 @@ unsafe impl LinkedListOps for AtomicLinkOps {
 
     #[inline]
     unsafe fn set_next(&mut self, ptr: Self::LinkPtr, next: Option<Self::LinkPtr>) {
-        ptr.as_ref().next_exclusive().set(next);
+        ptr.as_ref().set_next(next);
     }
 
     #[inline]
@@ -426,12 +428,12 @@ unsafe impl LinkedListOps for AtomicLinkOps {
 unsafe impl SinglyLinkedListOps for AtomicLinkOps {
     #[inline]
     unsafe fn next(&self, ptr: Self::LinkPtr) -> Option<Self::LinkPtr> {
-        ptr.as_ref().next_exclusive().get()
+        ptr.as_ref().next()
     }
 
     #[inline]
     unsafe fn set_next(&mut self, ptr: Self::LinkPtr, next: Option<Self::LinkPtr>) {
-        ptr.as_ref().next_exclusive().set(next);
+        ptr.as_ref().set_next(next);
     }
 }
 
@@ -444,8 +446,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) -> Option<Self::LinkPtr> {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let raw = packed ^ prev.map(|x| x.as_ptr() as usize).unwrap_or(0);
@@ -460,8 +461,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) -> Option<Self::LinkPtr> {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let raw = packed ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
@@ -479,7 +479,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
             ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
 
         let new_next = NonNull::new(new_packed as *mut _);
-        ptr.as_ref().next_exclusive().set(new_next);
+        ptr.as_ref().set_next(new_next);
     }
 
     #[inline]
@@ -491,8 +491,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let new_packed = packed
@@ -500,7 +499,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
             ^ new.map(|x| x.as_ptr() as usize).unwrap_or(0);
 
         let new_next = NonNull::new(new_packed as *mut _);
-        ptr.as_ref().next_exclusive().set(new_next);
+        ptr.as_ref().set_next(new_next);
     }
 }
 
@@ -2095,5 +2094,53 @@ mod tests {
     #[test]
     fn test_clone_pointer_arc() {
         test_clone_pointer!(Arc, std::sync::Arc);
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn atomic_link_is_linked_races_with_list_mutation() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        struct Obj {
+            link: super::AtomicLink,
+            value: usize,
+        }
+        intrusive_adapter!(ObjAdapter = Arc<Obj>: Obj { link => super::AtomicLink });
+
+        let obj = Arc::new(Obj {
+            link: super::AtomicLink::new(),
+            value: 1,
+        });
+        let mut list = LinkedList::new(ObjAdapter::new());
+        list.push_back(obj.clone());
+
+        let barrier = Barrier::new(3);
+        thread::scope(|scope| {
+            let obj = &obj;
+            let reader_barrier = &barrier;
+            scope.spawn(move || {
+                reader_barrier.wait();
+                // UB: `AtomicLink::is_linked` performs an atomic load, but
+                // `AtomicLinkOps` mutates the same word through a transmuted
+                // `Cell` after `acquire_link`. A safe `Arc` holder can call
+                // this while another thread mutates the list.
+                let _ = obj.link.is_linked();
+                reader_barrier.wait();
+            });
+
+            let list = &mut list;
+            let writer_barrier = &barrier;
+            scope.spawn(move || {
+                writer_barrier.wait();
+                let value = list.pop_front().unwrap();
+                assert_eq!(value.value, 1);
+                list.push_back(value);
+                writer_barrier.wait();
+            });
+
+            barrier.wait();
+            barrier.wait();
+        });
     }
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1440,6 +1440,7 @@ where
 unsafe impl<A: Adapter + Sync> Sync for LinkedList<A>
 where
     <A::PointerOps as PointerOps>::Value: Sync,
+    <A::PointerOps as PointerOps>::Pointer: Sync,
     A::LinkOps: LinkedListOps,
 {
 }

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -403,15 +403,15 @@ impl AtomicLink {
             .store(UNLINKED_MARKER, atomic::Ordering::Release);
     }
 
-    /// Access `parent_color` in an exclusive context.
-    ///
-    /// # Safety
-    ///
-    /// This can only be called after `acquire_link` has been succesfully called.
     #[inline]
-    unsafe fn parent_color_exclusive(&self) -> &Cell<usize> {
-        // This is safe because currently AtomicUsize has the same representation Cell<usize>.
-        core::mem::transmute(&self.parent_color)
+    fn parent_color(&self) -> usize {
+        self.parent_color.load(atomic::Ordering::Relaxed)
+    }
+
+    #[inline]
+    fn set_parent_color(&self, parent_color: usize) {
+        self.parent_color
+            .store(parent_color, atomic::Ordering::Relaxed);
     }
 }
 
@@ -478,9 +478,7 @@ impl AtomicLinkOps {
             Color::Black => 1,
         };
         let parent_usize = parent.map(|x| x.as_ptr() as usize).unwrap_or(0);
-        ptr.as_ref()
-            .parent_color_exclusive()
-            .set((parent_usize & !1) | bit);
+        ptr.as_ref().set_parent_color((parent_usize & !1) | bit);
     }
 }
 
@@ -523,13 +521,13 @@ unsafe impl RBTreeOps for AtomicLinkOps {
 
     #[inline]
     unsafe fn parent(&self, ptr: Self::LinkPtr) -> Option<Self::LinkPtr> {
-        let parent_usize = ptr.as_ref().parent_color_exclusive().get() & !1;
+        let parent_usize = ptr.as_ref().parent_color() & !1;
         NonNull::new(parent_usize as *mut AtomicLink)
     }
 
     #[inline]
     unsafe fn color(&self, ptr: Self::LinkPtr) -> Color {
-        if ptr.as_ref().parent_color_exclusive().get() & 1 == 1 {
+        if ptr.as_ref().parent_color() & 1 == 1 {
             Color::Black
         } else {
             Color::Red
@@ -3480,5 +3478,59 @@ mod tests {
         // node, but it leaves `head` pointing at that removed node. Alternating
         // back to `next` dereferences the freed link.
         let _ = iter.next();
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn atomic_link_is_linked_races_with_tree_mutation() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        struct Obj {
+            link: super::AtomicLink,
+            value: i32,
+        }
+        intrusive_adapter!(ObjAdapter = Arc<Obj>: Obj { link => super::AtomicLink });
+        impl<'a> KeyAdapter<'a> for ObjAdapter {
+            type Key = i32;
+
+            fn get_key(&self, value: &'a Obj) -> i32 {
+                value.value
+            }
+        }
+
+        let obj = Arc::new(Obj {
+            link: super::AtomicLink::new(),
+            value: 1,
+        });
+        let mut tree = RBTree::new(ObjAdapter::new());
+        tree.insert(obj.clone());
+
+        let barrier = Barrier::new(3);
+        thread::scope(|scope| {
+            let obj = &obj;
+            let reader_barrier = &barrier;
+            scope.spawn(move || {
+                reader_barrier.wait();
+                // UB: `AtomicLink::is_linked` performs an atomic load, but
+                // `AtomicLinkOps` updates the same `parent_color` word through
+                // a transmuted `Cell` during safe tree insertion. An outside
+                // `Arc` holder can observe it concurrently.
+                let _ = obj.link.is_linked();
+                reader_barrier.wait();
+            });
+
+            let tree = &mut tree;
+            let writer_barrier = &barrier;
+            scope.spawn(move || {
+                writer_barrier.wait();
+                let value = tree.front_mut().remove().unwrap();
+                tree.insert(value);
+                writer_barrier.wait();
+            });
+
+            barrier.wait();
+            barrier.wait();
+        });
     }
 }

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -2207,6 +2207,7 @@ where
 unsafe impl<A: Adapter + Sync> Sync for RBTree<A>
 where
     <A::PointerOps as PointerOps>::Value: Sync,
+    <A::PointerOps as PointerOps>::Pointer: Sync,
     A::LinkOps: RBTreeOps,
 {
 }

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -271,15 +271,17 @@ impl AtomicLink {
         self.next.store(ATOMIC_UNLINKED_MARKER, Ordering::Release);
     }
 
-    /// Access the `next` pointer in an exclusive context.
-    ///
-    /// # Safety
-    ///
-    /// This can only be called after `acquire_link` has been succesfully called.
     #[inline]
-    unsafe fn next_exclusive(&self) -> &Cell<Option<NonNull<AtomicLink>>> {
-        // This is safe because currently AtomicPtr<AtomicLink> has the same representation Cell<Option<NonNull<AtomicLink>>>.
-        core::mem::transmute(&self.next)
+    fn next(&self) -> Option<NonNull<AtomicLink>> {
+        NonNull::new(self.next.load(Ordering::Relaxed))
+    }
+
+    #[inline]
+    fn set_next(&self, next: Option<NonNull<AtomicLink>>) {
+        self.next.store(
+            next.map(|x| x.as_ptr()).unwrap_or(null_mut()),
+            Ordering::Relaxed,
+        );
     }
 }
 
@@ -359,12 +361,12 @@ unsafe impl link_ops::LinkOps for AtomicLinkOps {
 unsafe impl SinglyLinkedListOps for AtomicLinkOps {
     #[inline]
     unsafe fn next(&self, ptr: Self::LinkPtr) -> Option<Self::LinkPtr> {
-        ptr.as_ref().next_exclusive().get()
+        ptr.as_ref().next()
     }
 
     #[inline]
     unsafe fn set_next(&mut self, ptr: Self::LinkPtr, next: Option<Self::LinkPtr>) {
-        ptr.as_ref().next_exclusive().set(next);
+        ptr.as_ref().set_next(next);
     }
 }
 
@@ -377,8 +379,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) -> Option<Self::LinkPtr> {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let raw = packed ^ prev.map(|x| x.as_ptr() as usize).unwrap_or(0);
@@ -394,8 +395,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) -> Option<Self::LinkPtr> {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let raw = packed ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
@@ -413,7 +413,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
             ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
 
         let new_next = NonNull::new(new_packed as *mut _);
-        ptr.as_ref().next_exclusive().set(new_next);
+        ptr.as_ref().set_next(new_next);
     }
 
     #[inline]
@@ -425,8 +425,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) {
         let packed = ptr
             .as_ref()
-            .next_exclusive()
-            .get()
+            .next()
             .map(|x| x.as_ptr() as usize)
             .unwrap_or(0);
         let new_packed = packed
@@ -434,7 +433,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
             ^ new.map(|x| x.as_ptr() as usize).unwrap_or(0);
 
         let new_next = NonNull::new(new_packed as *mut _);
-        ptr.as_ref().next_exclusive().set(new_next);
+        ptr.as_ref().set_next(new_next);
     }
 }
 
@@ -1743,5 +1742,50 @@ mod tests {
     #[test]
     fn test_clone_pointer_arc() {
         test_clone_pointer!(Arc, std::sync::Arc);
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn atomic_link_is_linked_races_with_list_mutation() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use std::thread;
+
+        struct Obj {
+            link: super::AtomicLink,
+            value: usize,
+        }
+        intrusive_adapter!(ObjAdapter = Arc<Obj>: Obj { link => super::AtomicLink });
+
+        let obj = Arc::new(Obj {
+            link: super::AtomicLink::new(),
+            value: 1,
+        });
+        let mut list = SinglyLinkedList::new(ObjAdapter::new());
+        list.push_front(obj.clone());
+
+        let mutation_done = AtomicBool::new(false);
+        thread::scope(|scope| {
+            let obj = &obj;
+            let reader_done = &mutation_done;
+            scope.spawn(move || {
+                while !reader_done.load(Ordering::Relaxed) {
+                    thread::yield_now();
+                }
+                // UB: `AtomicLink::is_linked` performs an atomic load, but
+                // `AtomicLinkOps` writes the same `next` pointer through a
+                // transmuted `Cell` while safe list mutation is in progress.
+                let _ = obj.link.is_linked();
+            });
+
+            let list = &mut list;
+            let writer_done = &mutation_done;
+            scope.spawn(move || {
+                let value = list.pop_front().unwrap();
+                assert_eq!(value.value, 1);
+                list.push_front(value);
+                writer_done.store(true, Ordering::Relaxed);
+            });
+        });
     }
 }

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -1168,6 +1168,7 @@ where
 unsafe impl<A: Adapter + Sync> Sync for SinglyLinkedList<A>
 where
     <A::PointerOps as PointerOps>::Value: Sync,
+    <A::PointerOps as PointerOps>::Pointer: Sync,
     A::LinkOps: SinglyLinkedListOps,
 {
 }

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1620,6 +1620,7 @@ where
 unsafe impl<A: Adapter + Sync> Sync for XorLinkedList<A>
 where
     <A::PointerOps as PointerOps>::Value: Sync,
+    <A::PointerOps as PointerOps>::Pointer: Sync,
     A::LinkOps: XorLinkedListOps,
 {
 }

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -294,15 +294,14 @@ impl AtomicLink {
         self.packed.store(UNLINKED_MARKER, Ordering::Release);
     }
 
-    /// Access the `packed` pointer in an exclusive context.
-    ///
-    /// # Safety
-    ///
-    /// This can only be called after `acquire_link` has been succesfully called.
     #[inline]
-    unsafe fn packed_exclusive(&self) -> &Cell<usize> {
-        // This is safe because currently AtomicUsize has the same representation Cell<usize>.
-        core::mem::transmute(&self.packed)
+    fn packed(&self) -> usize {
+        self.packed.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    fn set_packed(&self, packed: usize) {
+        self.packed.store(packed, Ordering::Relaxed);
     }
 }
 
@@ -388,8 +387,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
         ptr: Self::LinkPtr,
         prev: Option<Self::LinkPtr>,
     ) -> Option<Self::LinkPtr> {
-        let raw =
-            ptr.as_ref().packed_exclusive().get() ^ prev.map(|x| x.as_ptr() as usize).unwrap_or(0);
+        let raw = ptr.as_ref().packed() ^ prev.map(|x| x.as_ptr() as usize).unwrap_or(0);
         NonNull::new(raw as *mut _)
     }
 
@@ -399,8 +397,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
         ptr: Self::LinkPtr,
         next: Option<Self::LinkPtr>,
     ) -> Option<Self::LinkPtr> {
-        let raw =
-            ptr.as_ref().packed_exclusive().get() ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
+        let raw = ptr.as_ref().packed() ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
         NonNull::new(raw as *mut _)
     }
 
@@ -413,7 +410,7 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
     ) {
         let new_packed = prev.map(|x| x.as_ptr() as usize).unwrap_or(0)
             ^ next.map(|x| x.as_ptr() as usize).unwrap_or(0);
-        ptr.as_ref().packed_exclusive().set(new_packed);
+        ptr.as_ref().set_packed(new_packed);
     }
 
     #[inline]
@@ -423,26 +420,25 @@ unsafe impl XorLinkedListOps for AtomicLinkOps {
         old: Option<Self::LinkPtr>,
         new: Option<Self::LinkPtr>,
     ) {
-        let new_packed = ptr.as_ref().packed_exclusive().get()
+        let new_packed = ptr.as_ref().packed()
             ^ old.map(|x| x.as_ptr() as usize).unwrap_or(0)
             ^ new.map(|x| x.as_ptr() as usize).unwrap_or(0);
 
-        ptr.as_ref().packed_exclusive().set(new_packed);
+        ptr.as_ref().set_packed(new_packed);
     }
 }
 
 unsafe impl SinglyLinkedListOps for AtomicLinkOps {
     #[inline]
     unsafe fn next(&self, ptr: Self::LinkPtr) -> Option<Self::LinkPtr> {
-        let raw = ptr.as_ref().packed_exclusive().get();
+        let raw = ptr.as_ref().packed();
         NonNull::new(raw as *mut _)
     }
 
     #[inline]
     unsafe fn set_next(&mut self, ptr: Self::LinkPtr, next: Option<Self::LinkPtr>) {
         ptr.as_ref()
-            .packed_exclusive()
-            .set(next.map(|x| x.as_ptr() as usize).unwrap_or(0));
+            .set_packed(next.map(|x| x.as_ptr() as usize).unwrap_or(0));
     }
 }
 
@@ -2510,5 +2506,50 @@ mod tests {
         }
 
         let _ = list.iter().map(|x| x.value).collect::<Vec<_>>();
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn atomic_link_is_linked_races_with_list_mutation() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use std::thread;
+
+        struct Obj {
+            link: super::AtomicLink,
+            value: usize,
+        }
+        intrusive_adapter!(ObjAdapter = Arc<Obj>: Obj { link => super::AtomicLink });
+
+        let obj = Arc::new(Obj {
+            link: super::AtomicLink::new(),
+            value: 1,
+        });
+        let mut list = XorLinkedList::new(ObjAdapter::new());
+        list.push_back(obj.clone());
+
+        let mutation_done = AtomicBool::new(false);
+        thread::scope(|scope| {
+            let obj = &obj;
+            let reader_done = &mutation_done;
+            scope.spawn(move || {
+                while !reader_done.load(Ordering::Relaxed) {
+                    thread::yield_now();
+                }
+                // UB: `AtomicLink::is_linked` performs an atomic load, but
+                // `AtomicLinkOps` updates the packed link word through a
+                // transmuted `Cell` during safe list mutation.
+                let _ = obj.link.is_linked();
+            });
+
+            let list = &mut list;
+            let writer_done = &mutation_done;
+            scope.spawn(move || {
+                let value = list.pop_front().unwrap();
+                assert_eq!(value.value, 1);
+                list.push_back(value);
+                writer_done.store(true, Ordering::Relaxed);
+            });
+        });
     }
 }


### PR DESCRIPTION
* Fixed incorrect `Sync` bounds on collection types.
* Fixed data races when using atomic link types.

Credits @Shnatsel for discovering and reporting these bugs.