### PR TITLE
Fix panic safety issues in Cursor in 3 data structures

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1127,13 +1127,33 @@ where
     /// All mutations of the cursor are reflected in the original.
     #[inline]
     pub fn with_cursor_mut<T>(&mut self, f: impl FnOnce(&mut CursorMut<'_, A>) -> T) -> T {
-        let mut cursor = CursorMut {
-            current: self.current,
-            list: &mut self.list,
+        struct WritebackOnDrop<'a, 'b, A: Adapter>
+        where
+            A::LinkOps: LinkedListOps,
+        {
+            current: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            cursor: CursorMut<'b, A>,
+        }
+
+        impl<'a, 'b, A: Adapter> Drop for WritebackOnDrop<'a, 'b, A>
+        where
+            A::LinkOps: LinkedListOps,
+        {
+            fn drop(&mut self) {
+                *self.current = self.cursor.current;
+            }
+        }
+
+        let current = self.current;
+        let mut guard = WritebackOnDrop {
+            current: &mut self.current,
+            cursor: CursorMut {
+                current,
+                list: &mut self.list,
+            },
         };
-        let ret = f(&mut cursor);
-        self.current = cursor.current;
-        ret
+
+        f(&mut guard.cursor)
     }
 }
 unsafe impl<A: Adapter> Send for CursorOwning<A>
@@ -2096,38 +2116,35 @@ mod tests {
         test_clone_pointer!(Arc, std::sync::Arc);
     }
 
-    #[cfg(miri)]
     #[test]
     fn cursor_owning_panic_leaves_dangling_current() {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
         struct Obj {
             link: Link,
-            value: u32,
+            _value: u32,
         }
         intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
 
         let mut list = LinkedList::new(ObjAdapter::new());
         list.push_back(Box::new(Obj {
             link: Link::new(),
-            value: 1,
+            _value: 1,
         }));
 
         let mut cursor = list.front_owning();
-        let _ = catch_unwind(AssertUnwindSafe(|| {
+        let panic = catch_unwind(AssertUnwindSafe(|| {
             cursor.with_cursor_mut(|cursor| {
                 drop(cursor.remove().unwrap());
                 panic!("leave CursorOwning state stale");
             });
         }));
 
-        // UB: `CursorOwning::with_cursor_mut` only copies the temporary
-        // cursor position back after the closure returns normally. If the
-        // closure removes and drops the current element and then panics, safe
-        // `catch_unwind` leaves `CursorOwning.current` pointing at freed
-        // storage. Turning it back into a shared cursor dereferences that
-        // dangling pointer.
-        let _ = cursor.as_cursor().get().unwrap().value;
+        assert!(panic.is_err());
+        // Regression test: without panic-safe cursor state writeback,
+        // `CursorOwning.current` still points at the removed and dropped node
+        // here, and `as_cursor().get()` dereferences freed storage under Miri.
+        assert!(cursor.as_cursor().is_null());
     }
 
     #[cfg(miri)]

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -2098,6 +2098,40 @@ mod tests {
 
     #[cfg(miri)]
     #[test]
+    fn cursor_owning_panic_leaves_dangling_current() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        struct Obj {
+            link: Link,
+            value: u32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+
+        let mut list = LinkedList::new(ObjAdapter::new());
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+
+        let mut cursor = list.front_owning();
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            cursor.with_cursor_mut(|cursor| {
+                drop(cursor.remove().unwrap());
+                panic!("leave CursorOwning state stale");
+            });
+        }));
+
+        // UB: `CursorOwning::with_cursor_mut` only copies the temporary
+        // cursor position back after the closure returns normally. If the
+        // closure removes and drops the current element and then panics, safe
+        // `catch_unwind` leaves `CursorOwning.current` pointing at freed
+        // storage. Turning it back into a shared cursor dereferences that
+        // dangling pointer.
+        let _ = cursor.as_cursor().get().unwrap().value;
+    }
+
+    #[cfg(miri)]
+    #[test]
     fn atomic_link_is_linked_races_with_list_mutation() {
         use std::sync::{Arc, Barrier};
         use std::thread;

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -1511,13 +1511,33 @@ where
     /// All mutations of the cursor are reflected in the original.
     #[inline]
     pub fn with_cursor_mut<T>(&mut self, f: impl FnOnce(&mut CursorMut<'_, A>) -> T) -> T {
-        let mut cursor = CursorMut {
-            current: self.current,
-            tree: &mut self.tree,
+        struct WritebackOnDrop<'a, 'b, A: Adapter>
+        where
+            A::LinkOps: RBTreeOps,
+        {
+            current: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            cursor: CursorMut<'b, A>,
+        }
+
+        impl<'a, 'b, A: Adapter> Drop for WritebackOnDrop<'a, 'b, A>
+        where
+            A::LinkOps: RBTreeOps,
+        {
+            fn drop(&mut self) {
+                *self.current = self.cursor.current;
+            }
+        }
+
+        let current = self.current;
+        let mut guard = WritebackOnDrop {
+            current: &mut self.current,
+            cursor: CursorMut {
+                current,
+                tree: &mut self.tree,
+            },
         };
-        let ret = f(&mut cursor);
-        self.current = cursor.current;
-        ret
+
+        f(&mut guard.cursor)
     }
 }
 unsafe impl<A: Adapter> Send for CursorOwning<A>
@@ -3449,7 +3469,6 @@ mod tests {
         test_clone_pointer!(Arc, std::sync::Arc);
     }
 
-    #[cfg(miri)]
     #[test]
     fn cursor_owning_panic_leaves_dangling_current() {
         use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -3474,19 +3493,18 @@ mod tests {
         }));
 
         let mut cursor = tree.front_owning();
-        let _ = catch_unwind(AssertUnwindSafe(|| {
+        let panic = catch_unwind(AssertUnwindSafe(|| {
             cursor.with_cursor_mut(|cursor| {
                 drop(cursor.remove().unwrap());
                 panic!("leave CursorOwning state stale");
             });
         }));
 
-        // UB: `CursorOwning::with_cursor_mut` writes the temporary cursor
-        // state back only after the closure returns normally. Safe
-        // `catch_unwind` can observe the owning cursor after the closure
-        // removed and dropped the current tree node, so `current` still points
-        // at freed storage and `as_cursor().get()` dereferences it.
-        let _ = cursor.as_cursor().get().unwrap().value;
+        assert!(panic.is_err());
+        // Regression test: without panic-safe cursor state writeback,
+        // `CursorOwning.current` still points at the removed and dropped node
+        // here, and `as_cursor().get()` dereferences freed storage under Miri.
+        assert!(cursor.as_cursor().is_null());
     }
 
     #[cfg(miri)]

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -3451,6 +3451,46 @@ mod tests {
 
     #[cfg(miri)]
     #[test]
+    fn cursor_owning_panic_leaves_dangling_current() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        struct Obj {
+            link: Link,
+            value: i32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+        impl<'a> KeyAdapter<'a> for ObjAdapter {
+            type Key = i32;
+
+            fn get_key(&self, value: &'a Obj) -> i32 {
+                value.value
+            }
+        }
+
+        let mut tree = RBTree::new(ObjAdapter::new());
+        tree.insert(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+
+        let mut cursor = tree.front_owning();
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            cursor.with_cursor_mut(|cursor| {
+                drop(cursor.remove().unwrap());
+                panic!("leave CursorOwning state stale");
+            });
+        }));
+
+        // UB: `CursorOwning::with_cursor_mut` writes the temporary cursor
+        // state back only after the closure returns normally. Safe
+        // `catch_unwind` can observe the owning cursor after the closure
+        // removed and dropped the current tree node, so `current` still points
+        // at freed storage and `as_cursor().get()` dereferences it.
+        let _ = cursor.as_cursor().get().unwrap().value;
+    }
+
+    #[cfg(miri)]
+    #[test]
     fn into_iter_next_after_next_back_uses_removed_tail() {
         struct Obj {
             link: Link,

--- a/src/singly_linked_list.rs
+++ b/src/singly_linked_list.rs
@@ -904,13 +904,33 @@ where
     /// All mutations of the cursor are reflected in the original.
     #[inline]
     pub fn with_cursor_mut<T>(&mut self, f: impl FnOnce(&mut CursorMut<'_, A>) -> T) -> T {
-        let mut cursor = CursorMut {
-            current: self.current,
-            list: &mut self.list,
+        struct WritebackOnDrop<'a, 'b, A: Adapter>
+        where
+            A::LinkOps: SinglyLinkedListOps,
+        {
+            current: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            cursor: CursorMut<'b, A>,
+        }
+
+        impl<'a, 'b, A: Adapter> Drop for WritebackOnDrop<'a, 'b, A>
+        where
+            A::LinkOps: SinglyLinkedListOps,
+        {
+            fn drop(&mut self) {
+                *self.current = self.cursor.current;
+            }
+        }
+
+        let current = self.current;
+        let mut guard = WritebackOnDrop {
+            current: &mut self.current,
+            cursor: CursorMut {
+                current,
+                list: &mut self.list,
+            },
         };
-        let ret = f(&mut cursor);
-        self.current = cursor.current;
-        ret
+
+        f(&mut guard.cursor)
     }
 }
 unsafe impl<A: Adapter> Send for CursorOwning<A>

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -1156,20 +1156,43 @@ where
     /// All mutations of the cursor are reflected in the original.
     #[inline]
     pub fn with_cursor_mut<T>(&mut self, f: impl FnOnce(&mut CursorMut<'_, A>) -> T) -> T {
-        let mut cursor = CursorMut {
-            current: self.current,
-            prev: self.prev,
-            next: self.next,
-            list: &mut self.list,
+        struct WritebackOnDrop<'a, 'b, A: Adapter>
+        where
+            A::LinkOps: XorLinkedListOps,
+        {
+            current: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            prev: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            next: &'a mut Option<<A::LinkOps as link_ops::LinkOps>::LinkPtr>,
+            cursor: CursorMut<'b, A>,
+        }
+
+        impl<'a, 'b, A: Adapter> Drop for WritebackOnDrop<'a, 'b, A>
+        where
+            A::LinkOps: XorLinkedListOps,
+        {
+            fn drop(&mut self) {
+                *self.current = self.cursor.current;
+                *self.prev = self.cursor.prev;
+                *self.next = self.cursor.next;
+            }
+        }
+
+        let current = self.current;
+        let prev = self.prev;
+        let next = self.next;
+        let mut guard = WritebackOnDrop {
+            current: &mut self.current,
+            prev: &mut self.prev,
+            next: &mut self.next,
+            cursor: CursorMut {
+                current,
+                prev,
+                next,
+                list: &mut self.list,
+            },
         };
 
-        let ret = f(&mut cursor);
-
-        self.current = cursor.current;
-        self.prev = cursor.prev;
-        self.next = cursor.next;
-
-        ret
+        f(&mut guard.cursor)
     }
 }
 unsafe impl<A: Adapter> Send for CursorOwning<A>
@@ -2424,37 +2447,35 @@ mod tests {
         test_clone_pointer!(Arc, std::sync::Arc);
     }
 
-    #[cfg(miri)]
     #[test]
     fn cursor_owning_panic_leaves_dangling_current() {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
         struct Obj {
             link: Link,
-            value: u32,
+            _value: u32,
         }
         intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
 
         let mut list = XorLinkedList::new(ObjAdapter::new());
         list.push_back(Box::new(Obj {
             link: Link::new(),
-            value: 1,
+            _value: 1,
         }));
 
         let mut cursor = list.front_owning();
-        let _ = catch_unwind(AssertUnwindSafe(|| {
+        let panic = catch_unwind(AssertUnwindSafe(|| {
             cursor.with_cursor_mut(|cursor| {
                 drop(cursor.remove().unwrap());
                 panic!("leave CursorOwning state stale");
             });
         }));
 
-        // UB: `CursorOwning::with_cursor_mut` updates `current`, `prev`, and
-        // `next` only after the closure returns normally. A panic after safe
-        // removal and drop of the current element leaves the owning cursor's
-        // saved `current` pointing at freed storage, and `as_cursor().get()`
-        // dereferences it.
-        let _ = cursor.as_cursor().get().unwrap().value;
+        assert!(panic.is_err());
+        // Regression test: without panic-safe cursor state writeback,
+        // `CursorOwning.current` still points at the removed and dropped node
+        // here, and `as_cursor().get()` dereferences freed storage under Miri.
+        assert!(cursor.as_cursor().is_null());
     }
 
     #[cfg(miri)]

--- a/src/xor_linked_list.rs
+++ b/src/xor_linked_list.rs
@@ -2426,6 +2426,39 @@ mod tests {
 
     #[cfg(miri)]
     #[test]
+    fn cursor_owning_panic_leaves_dangling_current() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        struct Obj {
+            link: Link,
+            value: u32,
+        }
+        intrusive_adapter!(ObjAdapter = Box<Obj>: Obj { link => Link });
+
+        let mut list = XorLinkedList::new(ObjAdapter::new());
+        list.push_back(Box::new(Obj {
+            link: Link::new(),
+            value: 1,
+        }));
+
+        let mut cursor = list.front_owning();
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            cursor.with_cursor_mut(|cursor| {
+                drop(cursor.remove().unwrap());
+                panic!("leave CursorOwning state stale");
+            });
+        }));
+
+        // UB: `CursorOwning::with_cursor_mut` updates `current`, `prev`, and
+        // `next` only after the closure returns normally. A panic after safe
+        // removal and drop of the current element leaves the owning cursor's
+        // saved `current` pointing at freed storage, and `as_cursor().get()`
+        // dereferences it.
+        let _ = cursor.as_cursor().get().unwrap().value;
+    }
+
+    #[cfg(miri)]
+    #[test]
     fn splice_before_head_corrupts_head_link() {
         struct Obj {
             link: Link,


### PR DESCRIPTION
The first commit adds PoC unit tests demonstrating UB under miri: use-after-free accesses after a caught panic in Cursor.

The second commit fixes the issues using a RAII guard.

The issue was discovered by GPT-5.5 and the fixes are heavily assisted by it.