### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ nightly = []
 alloc = []
 default = ["alloc"]
 
-[dependencies]
-memoffset = "0.9"
-
 [dev-dependencies]
 rand = "0.8.4"
 typed-arena = "2.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ pub use crate::unsafe_ref::UnsafeRef;
 pub use crate::xor_linked_list::AtomicLink as XorLinkedListAtomicLink;
 pub use crate::xor_linked_list::Link as XorLinkedListLink;
 pub use crate::xor_linked_list::XorLinkedList;
-pub use memoffset::offset_of;
+pub use core::mem::offset_of;
 
 /// An endpoint of a range of keys.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]


### PR DESCRIPTION
Hi! Thank you for your crate, I was trying to see if I could prune some dependencies from my project and found this indirect one.

---

[`core::mem::offset_of`](https://doc.rust-lang.org/std/mem/macro.offset_of.html) was stabilised in 1.77.0 which is below this crate's MSRV of 1.82

Keep re-exporting it so we don't break any dependent crates.

The memoffset crate itself [says](https://github.com/Gilnaa/memoffset/tree/153fc3d50f03755be53148bc3eb97390f9011e45#:~:text=If%20you%27re%20using%20a%20rustc%20version%20greater%20or%20equal%20to%201%2E77%2C%20this%20crate%27s%20offset%5Fof%21%28%29%20macro%20simply%20forwards%20to%20core%3A%3Amem%3A%3Aoffset%5Fof%21%28%29%2E):

> If you're using a rustc version greater or equal to 1.77, this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

Thus this change should not break any dependent crates with a version of rustc of 1.77 or above.

---

I ran the tests with `cargo test` which passed.